### PR TITLE
Update compute readme for getting server

### DIFF
--- a/lib/fog/azurerm/docs/compute.md
+++ b/lib/fog/azurerm/docs/compute.md
@@ -93,7 +93,7 @@ Get a single record of Server
 ```ruby
       server = azure_compute_service
                           .servers(resource_group: '<Resource Group name>')
-                          .get('Server name>')
+                          .get('<Resource Group name>', 'Server name>')
       puts "#{server.name}"
 ```
 

--- a/lib/fog/azurerm/models/compute/servers.rb
+++ b/lib/fog/azurerm/models/compute/servers.rb
@@ -17,9 +17,9 @@ module Fog
         end
 
         def get(resource_group_name, virtual_machine_name)
-          storage_account = service.get_virtual_machine(resource_group_name, virtual_machine_name)
-          storage_account_obj = Server.new(service: service)
-          storage_account_obj.merge_attributes(Server.parse(storage_account))
+          virtual_machine = service.get_virtual_machine(resource_group_name, virtual_machine_name)
+          virtual_machine_obj = Server.new(service: service)
+          virtual_machine_obj.merge_attributes(Server.parse(virtual_machine))
         end
       end
     end


### PR DESCRIPTION
`get` operation on the `servers` model of `compute` service is taking two arguments as resource group name and the server name. 

https://github.com/fog/fog-azure-rm/blob/master/lib/fog/azurerm/models/compute/servers.rb#L19

But the documentation mentioned with one argument only at https://github.com/fog/fog-azure-rm/blob/master/lib/fog/azurerm/docs/compute.md#retrieve-a-single-server

Plus renamed the typo in the `get` method implementation. 