### PR TITLE
Feature/fix code climate report generating issue

### DIFF
--- a/rake-script.sh
+++ b/rake-script.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ $TRAVIS_PULL_REQUEST != "true"]
+if [ $TRAVIS_PULL_REQUEST != "true" ]
 then
   rake cc_coverage
   export CODECLIMATE_REPO_TOKEN="b1401494baa004d90402414cb33a7fc6420fd3693e60c677a120ddefd7d84cfd"

--- a/rake-script.sh
+++ b/rake-script.sh
@@ -2,7 +2,10 @@
 if [ $TRAVIS_PULL_REQUEST != "true"]
 then
   rake cc_coverage
-  rake integration_tests
+  export CODECLIMATE_REPO_TOKEN="b1401494baa004d90402414cb33a7fc6420fd3693e60c677a120ddefd7d84cfd"
+  codeclimate-test-reporter --directory /home/travis/build/fog/fog-azure-rm/coverage
 else
   rake cc_coverage
+  export CODECLIMATE_REPO_TOKEN="b1401494baa004d90402414cb33a7fc6420fd3693e60c677a120ddefd7d84cfd"
+  codeclimate-test-reporter --directory /home/travis/build/fog/fog-azure-rm/coverage
 fi

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,10 @@ end
 
 if ENV['CODECLIMATE_REPO_TOKEN']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter 'test'
+    command_name 'Minitest'
+  end
 end
 
 require 'minitest/autorun'


### PR DESCRIPTION
This usage of the Code Climate Test Reporter is now deprecated. Since version

      1.0, we now require you to run `SimpleCov` in your test/spec helper, and then

      run the provided `codeclimate-test-reporter` binary separately to report your

      results to Code Climate.

      More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md