### PR TITLE
Use Fog::JSON.decode

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter' , '~> 1.0.0'
   spec.add_dependency 'fog-core', '~> 1.43.0'
+  spec.add_dependency 'fog-json', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0.0'
   spec.add_dependency 'azure_mgmt_compute', '~> 0.7.0'
   spec.add_dependency 'azure_mgmt_resources', '~> 0.7.0'

--- a/lib/fog/azurerm.rb
+++ b/lib/fog/azurerm.rb
@@ -5,6 +5,7 @@ require 'fog/azurerm/config'
 require 'fog/azurerm/utilities/general'
 require 'fog/azurerm/version'
 require 'fog/core'
+require 'fog/json'
 
 module Fog
   # Autoload Module for Credentials

--- a/lib/fog/azurerm/requests/sql/create_or_update_database.rb
+++ b/lib/fog/azurerm/requests/sql/create_or_update_database.rb
@@ -18,10 +18,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "SQL Database: #{database_hash[:name]} created successfully."
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
 
         private

--- a/lib/fog/azurerm/requests/sql/create_or_update_firewall_rule.rb
+++ b/lib/fog/azurerm/requests/sql/create_or_update_firewall_rule.rb
@@ -19,10 +19,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "SQL Firewall Rule : #{firewall_hash[:name]} created successfully."
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
 
         private

--- a/lib/fog/azurerm/requests/sql/create_or_update_sql_server.rb
+++ b/lib/fog/azurerm/requests/sql/create_or_update_sql_server.rb
@@ -18,10 +18,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "SQL Server: #{server_hash[:name]} created successfully."
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
 
         private

--- a/lib/fog/azurerm/requests/sql/delete_database.rb
+++ b/lib/fog/azurerm/requests/sql/delete_database.rb
@@ -16,7 +16,7 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "SQL Database: #{name} deleted successfully."
           true

--- a/lib/fog/azurerm/requests/sql/delete_firewall_rule.rb
+++ b/lib/fog/azurerm/requests/sql/delete_firewall_rule.rb
@@ -16,11 +16,11 @@ module Fog
               content_type: :json,
               authorization: token
             )
-            Fog::Logger.debug "SQL Firewall Rule: #{rule_name} deleted successfully."
-            true
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
+          Fog::Logger.debug "SQL Firewall Rule: #{rule_name} deleted successfully."
+          true
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/delete_sql_server.rb
+++ b/lib/fog/azurerm/requests/sql/delete_sql_server.rb
@@ -15,11 +15,11 @@ module Fog
               content_type: :json,
               authorization: token
             )
-            Fog::Logger.debug "SQL Server: #{name} deleted successfully."
-            true
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
+          Fog::Logger.debug "SQL Server: #{name} deleted successfully."
+          true
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/get_database.rb
+++ b/lib/fog/azurerm/requests/sql/get_database.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Database fetched successfully in Resource Group: #{resource_group}"
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/get_firewall_rule.rb
+++ b/lib/fog/azurerm/requests/sql/get_firewall_rule.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Server Firewall Rule fetched successfully from Server: #{server_name}, Resource Group: #{resource_group}"
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/get_sql_server.rb
+++ b/lib/fog/azurerm/requests/sql/get_sql_server.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Server fetched successfully in Resource Group: #{resource_group}"
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/list_databases.rb
+++ b/lib/fog/azurerm/requests/sql/list_databases.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Databases listed successfully in Resource Group: #{resource_group}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/list_firewall_rules.rb
+++ b/lib/fog/azurerm/requests/sql/list_firewall_rules.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Server Firewall Rules listed successfully on server: #{server_name} in Resource Group: #{resource_group}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 

--- a/lib/fog/azurerm/requests/sql/list_sql_servers.rb
+++ b/lib/fog/azurerm/requests/sql/list_sql_servers.rb
@@ -16,10 +16,10 @@ module Fog
               authorization: token
             )
           rescue RestClient::Exception => e
-            raise JSON.parse(e.response)['message']
+            raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Sql Servers listed successfully in Resource Group: #{resource_group}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 

--- a/lib/fog/azurerm/requests/storage/create_or_update_recovery_vault.rb
+++ b/lib/fog/azurerm/requests/storage/create_or_update_recovery_vault.rb
@@ -27,7 +27,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Recovery Vault #{name} created/updated successfully"
-          JSON.parse(response)
+          Fog::JSON.decode(response)
         end
       end
 
@@ -46,7 +46,7 @@ module Fog
               "name": "standard"
             }
           }'
-          JSON.parse(recovery_vault)
+          Fog::JSON.decode(recovery_vault)
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_all_backup_jobs.rb
+++ b/lib/fog/azurerm/requests/storage/get_all_backup_jobs.rb
@@ -20,7 +20,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Successfully retrieved backup jobs for Recovery Vault #{rv_name}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 
@@ -48,7 +48,7 @@ module Fog
               }
             }]
           }'
-          JSON.parse(body)['value']
+          Fog::JSON.decode(body)['value']
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_backup_container.rb
+++ b/lib/fog/azurerm/requests/storage/get_backup_container.rb
@@ -20,7 +20,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Successfully retrieved backup container from Recovery Vault #{rv_name}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 
@@ -45,7 +45,7 @@ module Fog
               }
             }]
           }'
-          JSON.parse(body)['value']
+          Fog::JSON.decode(body)['value']
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_backup_item.rb
+++ b/lib/fog/azurerm/requests/storage/get_backup_item.rb
@@ -20,7 +20,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Successfully retrieved backup item from Recovery Vault #{rv_name}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 
@@ -50,7 +50,7 @@ module Fog
               }
             }]
           }'
-          JSON.parse(body)['value']
+          Fog::JSON.decode(body)['value']
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_backup_job_for_vm.rb
+++ b/lib/fog/azurerm/requests/storage/get_backup_job_for_vm.rb
@@ -45,7 +45,7 @@ module Fog
               "activityId": "383f05d9-a4bf-4b95-bb41-d39849b3a86e-2016-10-13 09:55:53Z-PS"
             }
           }'
-          JSON.parse(body)
+          Fog::JSON.decode(body)
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_backup_protection_policy.rb
+++ b/lib/fog/azurerm/requests/storage/get_backup_protection_policy.rb
@@ -20,7 +20,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Successfully retrieved backup protection policy from Resource Group #{resource_group}"
-          JSON.parse(response)['value']
+          Fog::JSON.decode(response)['value']
         end
       end
 
@@ -57,7 +57,7 @@ module Fog
             }
           }]
         }'
-        JSON.parse(body)['value']
+        Fog::JSON.decode(body)['value']
       end
     end
   end

--- a/lib/fog/azurerm/requests/storage/get_recovery_vault.rb
+++ b/lib/fog/azurerm/requests/storage/get_recovery_vault.rb
@@ -19,7 +19,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Recovery Vault #{name} from Resource Group #{resource_group} retrieved successfully"
-          recovery_vault = JSON.parse(recovery_vault_response)['value']
+          recovery_vault = Fog::JSON.decode(recovery_vault_response)['value']
           recovery_vault.select { |vault| vault['name'].eql? name }[0]
         end
       end
@@ -41,7 +41,7 @@ module Fog
               }
             }]
           }'
-          JSON.parse(body)['value'][0]
+          Fog::JSON.decode(body)['value'][0]
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/list_recovery_vaults.rb
+++ b/lib/fog/azurerm/requests/storage/list_recovery_vaults.rb
@@ -19,7 +19,7 @@ module Fog
             raise_azure_exception(e, msg)
           end
           Fog::Logger.debug "Recovery Vaults in Resource Group #{resource_group} listed successfully"
-          JSON.parse(recovery_vaults_response)['value']
+          Fog::JSON.decode(recovery_vaults_response)['value']
         end
       end
 
@@ -40,7 +40,7 @@ module Fog
               }
             }]
           }'
-          JSON.parse(body)['value']
+          Fog::JSON.decode(body)['value']
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/start_backup.rb
+++ b/lib/fog/azurerm/requests/storage/start_backup.rb
@@ -16,7 +16,7 @@ module Fog
             return false
           end
 
-          backup_items = get_backup_item(resource_group, name, vm_name)
+          backup_items = get_backup_item(resource_group, name)
           backup_item = backup_items.select { |item| (item['properties']['friendlyName'].eql? vm_name.downcase) && (vm_resource_group.eql? get_resource_group_from_id(item['properties']['virtualMachineId'])) }[0]
 
           resource_url = "#{AZURE_RESOURCE}/subscriptions/#{@subscription_id}/resourceGroups/#{resource_group}/providers/Microsoft.RecoveryServices/vaults/#{name}/backupFabrics/Azure/protectionContainers/iaasvmcontainer;#{backup_item['name']}/protectedItems/vm;#{backup_item['name']}/backup?api-version=2016-05-01"

--- a/test/integration/sql_server.rb
+++ b/test/integration/sql_server.rb
@@ -34,7 +34,7 @@ resources.resource_groups.create(
 ########################################################################################################################
 ######################                         Create Sql Server                                  ######################
 ########################################################################################################################
-begin
+# begin
 server_name = rand(0...999_99)
 
 azure_sql_service.sql_servers.create(
@@ -64,10 +64,10 @@ azure_sql_service.sql_databases.create(
 
 sleep 60
 database = azure_sql_service.sql_databases.get('TestRG-SQL', server_name, database_name)
-rescue
-  resource_group = resources.resource_groups.get('TestRG-SQL')
-  resource_group.destroy
-end
+# rescue
+#   resource_group = resources.resource_groups.get('TestRG-SQL')
+#   resource_group.destroy
+# end
 Fog::Logger.debug "GET Database: #{database.name}"
 
 ########################################################################################################################


### PR DESCRIPTION
Updated code to use Fog::JSON.decode instead of JSON.parse
This was done to avoid any conflicts with other cloud providers present in fog.