### PR TITLE
Updated code to use namespace instead of only model name.

### DIFF
--- a/lib/fog/azurerm/models/application_gateway/gateway.rb
+++ b/lib/fog/azurerm/models/application_gateway/gateway.rb
@@ -39,62 +39,62 @@ module Fog
 
           hash['gateway_ip_configurations'] = []
           gateway.gateway_ipconfigurations.each do |ip_configuration|
-            gateway_ip_configuration = IPConfiguration.new
-            hash['gateway_ip_configurations'] << gateway_ip_configuration.merge_attributes(IPConfiguration.parse(ip_configuration))
+            gateway_ip_configuration = Fog::ApplicationGateway::AzureRM::IPConfiguration.new
+            hash['gateway_ip_configurations'] << gateway_ip_configuration.merge_attributes(Fog::ApplicationGateway::AzureRM::IPConfiguration.parse(ip_configuration))
           end unless gateway.gateway_ipconfigurations.nil?
 
           hash['ssl_certificates'] = []
           gateway.ssl_certificates.each do |certificate|
-            ssl_certificate = SslCertificate.new
-            hash['ssl_certificates'] << ssl_certificate.merge_attributes(SslCertificate.parse(certificate))
+            ssl_certificate = Fog::ApplicationGateway::AzureRM::SslCertificate.new
+            hash['ssl_certificates'] << ssl_certificate.merge_attributes(Fog::ApplicationGateway::AzureRM::SslCertificate.parse(certificate))
           end unless gateway.ssl_certificates.nil?
 
           hash['frontend_ip_configurations'] = []
           gateway.frontend_ipconfigurations.each do |frontend_ip_config|
-            frontend_ip_configuration = FrontendIPConfiguration.new
-            hash['frontend_ip_configurations'] << frontend_ip_configuration.merge_attributes(FrontendIPConfiguration.parse(frontend_ip_config))
+            frontend_ip_configuration = Fog::ApplicationGateway::AzureRM::FrontendIPConfiguration.new
+            hash['frontend_ip_configurations'] << frontend_ip_configuration.merge_attributes(Fog::ApplicationGateway::AzureRM::FrontendIPConfiguration.parse(frontend_ip_config))
           end unless gateway.frontend_ipconfigurations.nil?
 
           hash['frontend_ports'] = []
           gateway.frontend_ports.each do |port|
-            frontend_port = FrontendPort.new
-            hash['frontend_ports'] << frontend_port.merge_attributes(FrontendPort.parse(port))
+            frontend_port = Fog::ApplicationGateway::AzureRM::FrontendPort.new
+            hash['frontend_ports'] << frontend_port.merge_attributes(Fog::ApplicationGateway::AzureRM::FrontendPort.parse(port))
           end unless gateway.frontend_ports.nil?
 
           hash['probes'] = []
           gateway.probes.each do |probe|
-            gateway_probe = Probe.new
-            hash['probes'] << gateway_probe.merge_attributes(Probe.parse(probe))
+            gateway_probe = Fog::ApplicationGateway::AzureRM::Probe.new
+            hash['probes'] << gateway_probe.merge_attributes(Fog::ApplicationGateway::AzureRM::Probe.parse(probe))
           end unless gateway.probes.nil?
 
           hash['backend_address_pools'] = []
           gateway.backend_address_pools.each do |address|
-            backend_address_pool = BackendAddressPool.new
-            hash['backend_address_pools'] << backend_address_pool.merge_attributes(BackendAddressPool.parse(address))
+            backend_address_pool = Fog::ApplicationGateway::AzureRM::BackendAddressPool.new
+            hash['backend_address_pools'] << backend_address_pool.merge_attributes(Fog::ApplicationGateway::AzureRM::BackendAddressPool.parse(address))
           end unless gateway.backend_address_pools.nil?
 
           hash['backend_http_settings_list'] = []
           gateway.backend_http_settings_collection.each do |http_setting|
-            backend_http_setting = BackendHttpSetting.new
-            hash['backend_http_settings_list'] << backend_http_setting.merge_attributes(BackendHttpSetting.parse(http_setting))
+            backend_http_setting = Fog::ApplicationGateway::AzureRM::BackendHttpSetting.new
+            hash['backend_http_settings_list'] << backend_http_setting.merge_attributes(Fog::ApplicationGateway::AzureRM::BackendHttpSetting.parse(http_setting))
           end unless gateway.backend_http_settings_collection.nil?
 
           hash['http_listeners'] = []
           gateway.http_listeners.each do |listener|
-            http_listener = HttpListener.new
-            hash['http_listeners'] << http_listener.merge_attributes(HttpListener.parse(listener))
+            http_listener = Fog::ApplicationGateway::AzureRM::HttpListener.new
+            hash['http_listeners'] << http_listener.merge_attributes(Fog::ApplicationGateway::AzureRM::HttpListener.parse(listener))
           end unless gateway.http_listeners.nil?
 
           hash['url_path_maps'] = []
           gateway.url_path_maps.each do |map|
-            url_path_map = UrlPathMap.new
-            hash['url_path_maps'] << url_path_map.merge_attributes(UrlPathMap.parse(map))
+            url_path_map = Fog::ApplicationGateway::AzureRM::UrlPathMap.new
+            hash['url_path_maps'] << url_path_map.merge_attributes(Fog::ApplicationGateway::AzureRM::UrlPathMap.parse(map))
           end unless gateway.url_path_maps.nil?
 
           hash['request_routing_rules'] = []
           gateway.request_routing_rules.each do |rule|
-            request_routing_rule = RequestRoutingRule.new
-            hash['request_routing_rules'] << request_routing_rule.merge_attributes(RequestRoutingRule.parse(rule))
+            request_routing_rule = Fog::ApplicationGateway::AzureRM::RequestRoutingRule.new
+            hash['request_routing_rules'] << request_routing_rule.merge_attributes(Fog::ApplicationGateway::AzureRM::RequestRoutingRule.parse(rule))
           end unless gateway.request_routing_rules.nil?
           hash
         end
@@ -113,7 +113,7 @@ module Fog
           validate_url_path_maps(url_path_maps) unless url_path_maps.nil?
           validate_request_routing_rules(request_routing_rules) unless request_routing_rules.nil?
           gateway = service.create_or_update_application_gateway(application_gateway_params)
-          merge_attributes(Gateway.parse(gateway))
+          merge_attributes(Fog::ApplicationGateway::AzureRM::Gateway.parse(gateway))
         end
 
         def application_gateway_params

--- a/lib/fog/azurerm/models/application_gateway/gateways.rb
+++ b/lib/fog/azurerm/models/application_gateway/gateways.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # Application Gateway collection class for Application Gateway Service
       class Gateways < Fog::Collection
-        model Gateway
+        model Fog::ApplicationGateway::AzureRM::Gateway
         attribute :resource_group
 
         def all
           requires :resource_group
           application_gateways = []
           service.list_application_gateways(resource_group).each do |gateway|
-            application_gateways << Gateway.parse(gateway)
+            application_gateways << Fog::ApplicationGateway::AzureRM::Gateway.parse(gateway)
           end
           load(application_gateways)
         end
 
         def get(resource_group_name, application_gateway_name)
           gateway = service.get_application_gateway(resource_group_name, application_gateway_name)
-          application_gateway = Gateway.new(service: service)
-          application_gateway.merge_attributes(Gateway.parse(gateway))
+          application_gateway = Fog::ApplicationGateway::AzureRM::Gateway.new(service: service)
+          application_gateway.merge_attributes(Fog::ApplicationGateway::AzureRM::Gateway.parse(gateway))
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/availability_sets.rb
+++ b/lib/fog/azurerm/models/compute/availability_sets.rb
@@ -4,7 +4,7 @@ module Fog
       # This class is giving implementation of all/list, get and
       # check name availability for storage account.
       class AvailabilitySets < Fog::Collection
-        model AvailabilitySet
+        model Fog::Compute::AzureRM::AvailabilitySet
         attribute :resource_group
         def all
           accounts = []
@@ -13,7 +13,7 @@ module Fog
             service.list_availability_sets(resource_group)
           unless list_of_availability_sets.nil?
             list_of_availability_sets.each do |account|
-              parse_response = AvailabilitySet.parse(account)
+              parse_response = Fog::Compute::AzureRM::AvailabilitySet.parse(account)
               accounts << parse_response
             end
           end
@@ -22,8 +22,8 @@ module Fog
 
         def get(resource_group, identity)
           availability_set = service.get_availability_set(resource_group, identity)
-          availability_set_fog = AvailabilitySet.new(service: service)
-          availability_set_fog.merge_attributes(AvailabilitySet.parse(availability_set))
+          availability_set_fog = Fog::Compute::AzureRM::AvailabilitySet.new(service: service)
+          availability_set_fog.merge_attributes(Fog::Compute::AzureRM::AvailabilitySet.parse(availability_set))
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/server.rb
+++ b/lib/fog/azurerm/models/compute/server.rb
@@ -116,12 +116,12 @@ module Fog
 
         def attach_data_disk(disk_name, disk_size, storage_account_name)
           vm = service.attach_data_disk_to_vm(resource_group, name, disk_name, disk_size, storage_account_name)
-          merge_attributes(Server.parse(vm))
+          merge_attributes(Fog::Compute::AzureRM::Server.parse(vm))
         end
 
         def detach_data_disk(disk_name)
           vm = service.detach_data_disk_from_vm(resource_group, name, disk_name)
-          merge_attributes(Server.parse(vm))
+          merge_attributes(Fog::Compute::AzureRM::Server.parse(vm))
         end
 
         private

--- a/lib/fog/azurerm/models/compute/servers.rb
+++ b/lib/fog/azurerm/models/compute/servers.rb
@@ -5,21 +5,21 @@ module Fog
       # for Server.
       class Servers < Fog::Collection
         attribute :resource_group
-        model Server
+        model Fog::Compute::AzureRM::Server
 
         def all
           requires :resource_group
           virtual_machines = []
           service.list_virtual_machines(resource_group).each do |vm|
-            virtual_machines << Server.parse(vm)
+            virtual_machines << Fog::Compute::AzureRM::Server.parse(vm)
           end
           load(virtual_machines)
         end
 
         def get(resource_group_name, virtual_machine_name)
           virtual_machine = service.get_virtual_machine(resource_group_name, virtual_machine_name)
-          virtual_machine_fog = Server.new(service: service)
-          virtual_machine_fog.merge_attributes(Server.parse(virtual_machine))
+          virtual_machine_fog = Fog::Compute::AzureRM::Server.new(service: service)
+          virtual_machine_fog.merge_attributes(Fog::Compute::AzureRM::Server.parse(virtual_machine))
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/virtual_machine_extension.rb
+++ b/lib/fog/azurerm/models/compute/virtual_machine_extension.rb
@@ -34,14 +34,14 @@ module Fog
         def save
           requires :resource_group, :location, :name, :vm_name, :type, :publisher, :type_handler_version, :settings
           vm_extension = service.create_or_update_vm_extension(vm_extension_params)
-          merge_attributes(VirtualMachineExtension.parse(vm_extension))
+          merge_attributes(Fog::Compute::AzureRM::VirtualMachineExtension.parse(vm_extension))
         end
 
         def update(vm_extension_input)
           validate_input(vm_extension_input)
           merge_attributes(vm_extension_input) unless vm_extension_input.empty?
           vm_extension = service.create_or_update_vm_extension(vm_extension_params)
-          merge_attributes(VirtualMachineExtension.parse(vm_extension))
+          merge_attributes(Fog::Compute::AzureRM::VirtualMachineExtension.parse(vm_extension))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
+++ b/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class gives the implementation for get for virtual machine extension
       class VirtualMachineExtensions < Fog::Collection
-        model VirtualMachineExtension
+        model Fog::Compute::AzureRM::VirtualMachineExtension
         attribute :resource_group
         attribute :vm_name
 
@@ -11,15 +11,15 @@ module Fog
           requires :resource_group, :vm_name
           vm_extensions = []
           service.get_virtual_machine(resource_group, vm_name).resources.compact.each do |extension|
-            vm_extensions << VirtualMachineExtension.parse(extension)
+            vm_extensions << Fog::Compute::AzureRM::VirtualMachineExtension.parse(extension)
           end
           load(vm_extensions)
         end
 
         def get(resource_group_name, virtual_machine_name, vm_extension_name)
           vm_extension = service.get_vm_extension(resource_group_name, virtual_machine_name, vm_extension_name)
-          vm_extension_fog = VirtualMachineExtension.new(service: service)
-          vm_extension_fog.merge_attributes(VirtualMachineExtension.parse(vm_extension))
+          vm_extension_fog = Fog::Compute::AzureRM::VirtualMachineExtension.new(service: service)
+          vm_extension_fog.merge_attributes(Fog::Compute::AzureRM::VirtualMachineExtension.parse(vm_extension))
         end
       end
     end

--- a/lib/fog/azurerm/models/dns/record_sets.rb
+++ b/lib/fog/azurerm/models/dns/record_sets.rb
@@ -8,21 +8,21 @@ module Fog
         attribute :zone_name
         attribute :type
 
-        model RecordSet
+        model Fog::DNS::AzureRM::RecordSet
 
         def all
           requires :resource_group, :zone_name
           record_sets = []
           service.list_record_sets(resource_group, zone_name).each do |r|
-            record_sets << RecordSet.parse(r)
+            record_sets << Fog::DNS::AzureRM::RecordSet.parse(r)
           end
           load(record_sets)
         end
 
         def get(resource_group, name, zone_name, record_type)
           record_set = service.get_record_set(resource_group, name, zone_name, record_type)
-          record_set_fog = RecordSet.new(service: service)
-          record_set_fog.merge_attributes(RecordSet.parse(record_set))
+          record_set_fog = Fog::DNS::AzureRM::RecordSet.new(service: service)
+          record_set_fog.merge_attributes(Fog::DNS::AzureRM::RecordSet.parse(record_set))
         end
       end
     end

--- a/lib/fog/azurerm/models/dns/zones.rb
+++ b/lib/fog/azurerm/models/dns/zones.rb
@@ -4,20 +4,20 @@ module Fog
       # This class is giving implementation of
       # all/get for Zones.
       class Zones < Fog::Collection
-        model Zone
+        model Fog::DNS::AzureRM::Zone
 
         def all
           zones = []
           service.list_zones.each do |z|
-            zones << Zone.parse(z)
+            zones << Fog::DNS::AzureRM::Zone.parse(z)
           end
           load(zones)
         end
 
         def get(resource_group, name)
           zone = service.get_zone(resource_group, name)
-          zone_fog = Zone.new(service: service)
-          zone_fog.merge_attributes(Zone.parse(zone))
+          zone_fog = Fog::DNS::AzureRM::Zone.new(service: service)
+          zone_fog.merge_attributes(Fog::DNS::AzureRM::Zone.parse(zone))
         end
 
         def check_for_zone(resource_group, name)

--- a/lib/fog/azurerm/models/network/express_route_circuit.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit.rb
@@ -47,8 +47,8 @@ module Fog
           end
           express_route_circuit['peerings'] = []
           circuit.peerings.each do |peering|
-            circuit_peering = ExpressRouteCircuitPeering.new
-            express_route_circuit['peerings'] << circuit_peering.merge_attributes(ExpressRouteCircuitPeering.parse(peering))
+            circuit_peering = Fog::Network::AzureRM::ExpressRouteCircuitPeering.new
+            express_route_circuit['peerings'] << circuit_peering.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitPeering.parse(peering))
           end unless circuit.peerings.nil?
           express_route_circuit
         end
@@ -56,7 +56,7 @@ module Fog
         def save
           requires :location, :tags, :resource_group, :service_provider_name, :peering_location, :bandwidth_in_mbps
           circuit = service.create_or_update_express_route_circuit(express_route_circuit_params)
-          merge_attributes(ExpressRouteCircuit.parse(circuit))
+          merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuit.parse(circuit))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/express_route_circuit_authorization.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit_authorization.rb
@@ -23,7 +23,7 @@ module Fog
         def save
           requires :name, :resource_group, :circuit_name
           circuit_authorization = service.create_or_update_express_route_circuit_authorization(express_route_circuit_authorization_params)
-          merge_attributes(ExpressRouteCircuitAuthorization.parse(circuit_authorization))
+          merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitAuthorization.parse(circuit_authorization))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/express_route_circuit_authorizations.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit_authorizations.rb
@@ -3,20 +3,20 @@ module Fog
     class AzureRM
       # ExpressRouteCircuitAuthorization collection class for Network Service
       class ExpressRouteCircuitAuthorizations < Fog::Collection
-        model ExpressRouteCircuitAuthorization
+        model Fog::Network::AzureRM::ExpressRouteCircuitAuthorization
         attribute :resource_group
         attribute :circuit_name
 
         def all
           requires :resource_group, :circuit_name
-          circuit_authorizations = service.list_express_route_circuit_authorizations(resource_group, circuit_name).map { |circuit_authorization| ExpressRouteCircuitAuthorization.parse(circuit_authorization) }
+          circuit_authorizations = service.list_express_route_circuit_authorizations(resource_group, circuit_name).map { |circuit_authorization| Fog::Network::AzureRM::ExpressRouteCircuitAuthorization.parse(circuit_authorization) }
           load(circuit_authorizations)
         end
 
         def get(resource_group_name, circuit_name, authorization_name)
           circuit_authorization = service.get_express_route_circuit_authorization(resource_group_name, circuit_name, authorization_name)
-          express_route_circuit_authorization = ExpressRouteCircuitAuthorization.new(service: service)
-          express_route_circuit_authorization.merge_attributes(ExpressRouteCircuitAuthorization.parse(circuit_authorization))
+          express_route_circuit_authorization = Fog::Network::AzureRM::ExpressRouteCircuitAuthorization.new(service: service)
+          express_route_circuit_authorization.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitAuthorization.parse(circuit_authorization))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/express_route_circuit_peering.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit_peering.rb
@@ -60,7 +60,7 @@ module Fog
           requires :name, :resource_group, :circuit_name, :peering_type, :peer_asn, :primary_peer_address_prefix, :secondary_peer_address_prefix, :vlan_id
           requires :advertised_public_prefixes if peering_type.casecmp(MICROSOFT_PEERING) == 0
           circuit_peering = service.create_or_update_express_route_circuit_peering(express_route_circuit_peering_params)
-          merge_attributes(ExpressRouteCircuitPeering.parse(circuit_peering))
+          merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitPeering.parse(circuit_peering))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/express_route_circuit_peerings.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit_peerings.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # ExpressRouteCircuitPeering collection class for Network Service
       class ExpressRouteCircuitPeerings < Fog::Collection
-        model ExpressRouteCircuitPeering
+        model Fog::Network::AzureRM::ExpressRouteCircuitPeering
         attribute :resource_group
         attribute :circuit_name
 
@@ -11,15 +11,15 @@ module Fog
           requires :resource_group, :circuit_name
           circuit_peerings = []
           service.list_express_route_circuit_peerings(resource_group, circuit_name).each do |circuit_peering|
-            circuit_peerings << ExpressRouteCircuitPeering.parse(circuit_peering)
+            circuit_peerings << Fog::Network::AzureRM::ExpressRouteCircuitPeering.parse(circuit_peering)
           end
           load(circuit_peerings)
         end
 
         def get(resource_group_name, peering_name, circuit_name)
           circuit_peering = service.get_express_route_circuit_peering(resource_group_name, peering_name, circuit_name)
-          express_route_circuit_peering = ExpressRouteCircuitPeering.new(service: service)
-          express_route_circuit_peering.merge_attributes(ExpressRouteCircuitPeering.parse(circuit_peering))
+          express_route_circuit_peering = Fog::Network::AzureRM::ExpressRouteCircuitPeering.new(service: service)
+          express_route_circuit_peering.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitPeering.parse(circuit_peering))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/express_route_circuits.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuits.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # ExpressRouteCircuit collection class for Network Service
       class ExpressRouteCircuits < Fog::Collection
-        model ExpressRouteCircuit
+        model Fog::Network::AzureRM::ExpressRouteCircuit
         attribute :resource_group
 
         def all
           requires :resource_group
           express_route_circuits = []
           service.list_express_route_circuits(resource_group).each do |circuit|
-            express_route_circuits << ExpressRouteCircuit.parse(circuit)
+            express_route_circuits << Fog::Network::AzureRM::ExpressRouteCircuit.parse(circuit)
           end
           load(express_route_circuits)
         end
 
         def get(resource_group_name, name)
           circuit = service.get_express_route_circuit(resource_group_name, name)
-          express_route_circuit = ExpressRouteCircuit.new(service: service)
-          express_route_circuit.merge_attributes(ExpressRouteCircuit.parse(circuit))
+          express_route_circuit = Fog::Network::AzureRM::ExpressRouteCircuit.new(service: service)
+          express_route_circuit.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuit.parse(circuit))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/express_route_service_providers.rb
+++ b/lib/fog/azurerm/models/network/express_route_service_providers.rb
@@ -3,12 +3,12 @@ module Fog
     class AzureRM
       # ExpressRouteServiceProvider collection class for Network Service
       class ExpressRouteServiceProviders < Fog::Collection
-        model ExpressRouteServiceProvider
+        model Fog::Network::AzureRM::ExpressRouteServiceProvider
 
         def all
           express_route_service_providers = []
           service.list_express_route_service_providers.each do |service_provider|
-            express_route_service_providers << ExpressRouteServiceProvider.parse(service_provider)
+            express_route_service_providers << Fog::Network::AzureRM::ExpressRouteServiceProvider.parse(service_provider)
           end
           load(express_route_service_providers)
         end

--- a/lib/fog/azurerm/models/network/load_balancers.rb
+++ b/lib/fog/azurerm/models/network/load_balancers.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # LoadBalancers collection class for Network Service
       class LoadBalancers < Fog::Collection
-        model LoadBalancer
+        model Fog::Network::AzureRM::LoadBalancer
         attribute :resource_group
 
         def all
           requires :resource_group
           load_balancers = []
           service.list_load_balancers(resource_group).each do |load_balancer|
-            load_balancers << LoadBalancer.parse(load_balancer)
+            load_balancers << Fog::Network::AzureRM::LoadBalancer.parse(load_balancer)
           end
           load(load_balancers)
         end
 
         def get(resource_group_name, load_balancer_name)
           load_balancer = service.get_load_balancer(resource_group_name, load_balancer_name)
-          load_balancer_fog = LoadBalancer.new(service: service)
-          load_balancer_fog.merge_attributes(LoadBalancer.parse(load_balancer))
+          load_balancer_fog = Fog::Network::AzureRM::LoadBalancer.new(service: service)
+          load_balancer_fog.merge_attributes(Fog::Network::AzureRM::LoadBalancer.parse(load_balancer))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/local_network_gateway.rb
+++ b/lib/fog/azurerm/models/network/local_network_gateway.rb
@@ -33,7 +33,7 @@ module Fog
         def save
           requires :name, :location, :resource_group, :local_network_address_space_prefixes, :gateway_ip_address, :asn, :bgp_peering_address, :peer_weight
           local_network_gateway = service.create_or_update_local_network_gateway(local_network_gateway_parameters)
-          merge_attributes(LocalNetworkGateway.parse(local_network_gateway))
+          merge_attributes(Fog::Network::AzureRM::LocalNetworkGateway.parse(local_network_gateway))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/local_network_gateways.rb
+++ b/lib/fog/azurerm/models/network/local_network_gateways.rb
@@ -3,19 +3,19 @@ module Fog
     class AzureRM
       # LocalNetworkGateways collection class for Network Service
       class LocalNetworkGateways < Fog::Collection
-        model LocalNetworkGateway
+        model Fog::Network::AzureRM::LocalNetworkGateway
         attribute :resource_group
 
         def all
           requires :resource_group
-          local_network_gateways = service.list_local_network_gateways(resource_group).map { |gateway| LocalNetworkGateway.parse(gateway) }
+          local_network_gateways = service.list_local_network_gateways(resource_group).map { |gateway| Fog::Network::AzureRM::LocalNetworkGateway.parse(gateway) }
           load(local_network_gateways)
         end
 
         def get(resource_group_name, name)
           local_network_gateway = service.get_local_network_gateway(resource_group_name, name)
-          local_network_gateway_fog = LocalNetworkGateway.new(service: service)
-          local_network_gateway_fog.merge_attributes(LocalNetworkGateway.parse(local_network_gateway))
+          local_network_gateway_fog = Fog::Network::AzureRM::LocalNetworkGateway.new(service: service)
+          local_network_gateway_fog.merge_attributes(Fog::Network::AzureRM::LocalNetworkGateway.parse(local_network_gateway))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_interfaces.rb
+++ b/lib/fog/azurerm/models/network/network_interfaces.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # NetworkInterfaces collection class for Network Service
       class NetworkInterfaces < Fog::Collection
-        model NetworkInterface
+        model Fog::Network::AzureRM::NetworkInterface
         attribute :resource_group
 
         def all
           requires :resource_group
           network_interfaces = []
           service.list_network_interfaces(resource_group).each do |nic|
-            network_interfaces << NetworkInterface.parse(nic)
+            network_interfaces << Fog::Network::AzureRM::NetworkInterface.parse(nic)
           end
           load(network_interfaces)
         end
 
         def get(resource_group_name, name)
           network_interface_card = service.get_network_interface(resource_group_name, name)
-          network_interface_card_fog = NetworkInterface.new(service: service)
-          network_interface_card_fog.merge_attributes(NetworkInterface.parse(network_interface_card))
+          network_interface_card_fog = Fog::Network::AzureRM::NetworkInterface.new(service: service)
+          network_interface_card_fog.merge_attributes(Fog::Network::AzureRM::NetworkInterface.parse(network_interface_card))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_security_groups.rb
+++ b/lib/fog/azurerm/models/network/network_security_groups.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # collection class for Network Security Group
       class NetworkSecurityGroups < Fog::Collection
-        model NetworkSecurityGroup
+        model Fog::Network::AzureRM::NetworkSecurityGroup
         attribute :resource_group
 
         def all
           requires :resource_group
           network_security_groups = []
           service.list_network_security_groups(resource_group).each do |nsg|
-            network_security_groups << NetworkSecurityGroup.parse(nsg)
+            network_security_groups << Fog::Network::AzureRM::NetworkSecurityGroup.parse(nsg)
           end
           load(network_security_groups)
         end
 
         def get(resource_group, name)
           network_security_group = service.get_network_security_group(resource_group, name)
-          network_security_group_fog = NetworkSecurityGroup.new(service: service)
-          network_security_group_fog.merge_attributes(NetworkSecurityGroup.parse(network_security_group))
+          network_security_group_fog = Fog::Network::AzureRM::NetworkSecurityGroup.new(service: service)
+          network_security_group_fog.merge_attributes(Fog::Network::AzureRM::NetworkSecurityGroup.parse(network_security_group))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_security_rule.rb
+++ b/lib/fog/azurerm/models/network/network_security_rule.rb
@@ -38,7 +38,7 @@ module Fog
         def save
           requires :name, :network_security_group_name, :resource_group, :protocol, :source_port_range, :destination_port_range, :source_address_prefix, :destination_address_prefix, :access, :priority, :direction
           network_security_rule = service.create_or_update_network_security_rule(security_rule_params)
-          merge_attributes(NetworkSecurityRule.parse(network_security_rule))
+          merge_attributes(Fog::Network::AzureRM::NetworkSecurityRule.parse(network_security_rule))
         end
 
         def security_rule_params

--- a/lib/fog/azurerm/models/network/network_security_rules.rb
+++ b/lib/fog/azurerm/models/network/network_security_rules.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # collection class for Network Security Rule
       class NetworkSecurityRules < Fog::Collection
-        model NetworkSecurityRule
+        model Fog::Network::AzureRM::NetworkSecurityRule
         attribute :resource_group
         attribute :network_security_group_name
 
@@ -11,15 +11,15 @@ module Fog
           requires :resource_group, :network_security_group_name
           network_security_rules = []
           service.list_network_security_rules(resource_group, network_security_group_name).each do |nsr|
-            network_security_rules << NetworkSecurityRule.parse(nsr)
+            network_security_rules << Fog::Network::AzureRM::NetworkSecurityRule.parse(nsr)
           end
           load(network_security_rules)
         end
 
         def get(resource_group, network_security_group_name, name)
           network_security_rule = service.get_network_security_rule(resource_group, network_security_group_name, name)
-          network_security_rule_fog = NetworkSecurityRule.new(service: service)
-          network_security_rule_fog.merge_attributes(NetworkSecurityRule.parse(network_security_rule))
+          network_security_rule_fog = Fog::Network::AzureRM::NetworkSecurityRule.new(service: service)
+          network_security_rule_fog.merge_attributes(Fog::Network::AzureRM::NetworkSecurityRule.parse(network_security_rule))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/public_ips.rb
+++ b/lib/fog/azurerm/models/network/public_ips.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # PublicIPs collection class for Network Service
       class PublicIps < Fog::Collection
-        model PublicIp
+        model Fog::Network::AzureRM::PublicIp
         attribute :resource_group
 
         def all
           requires :resource_group
           public_ips = []
           service.list_public_ips(resource_group).each do |pip|
-            public_ips << PublicIp.parse(pip)
+            public_ips << Fog::Network::AzureRM::PublicIp.parse(pip)
           end
           load(public_ips)
         end
 
         def get(resource_group_name, public_ip_name)
           public_ip = service.get_public_ip(resource_group_name, public_ip_name)
-          public_ip_fog = PublicIp.new(service: service)
-          public_ip_fog.merge_attributes(PublicIp.parse(public_ip))
+          public_ip_fog = Fog::Network::AzureRM::PublicIp.new(service: service)
+          public_ip_fog.merge_attributes(Fog::Network::AzureRM::PublicIp.parse(public_ip))
         end
 
         def check_if_exists(resource_group, name)

--- a/lib/fog/azurerm/models/network/subnets.rb
+++ b/lib/fog/azurerm/models/network/subnets.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # Subnet collection for network service
       class Subnets < Fog::Collection
-        model Subnet
+        model Fog::Network::AzureRM::Subnet
         attribute :resource_group
         attribute :virtual_network_name
 
@@ -11,15 +11,15 @@ module Fog
           requires :resource_group, :virtual_network_name
           subnets = []
           service.list_subnets(resource_group, virtual_network_name).each do |subnet|
-            subnets << Subnet.parse(subnet)
+            subnets << Fog::Network::AzureRM::Subnet.parse(subnet)
           end
           load(subnets)
         end
 
         def get(resource_group, virtual_network_name, subnet_name)
           subnet = service.get_subnet(resource_group, virtual_network_name, subnet_name)
-          subnet_fog = Subnet.new(service: service)
-          subnet_fog.merge_attributes(Subnet.parse(subnet))
+          subnet_fog = Fog::Network::AzureRM::Subnet.new(service: service)
+          subnet_fog.merge_attributes(Fog::Network::AzureRM::Subnet.parse(subnet))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_network_gateway.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateway.rb
@@ -52,13 +52,13 @@ module Fog
 
           hash['ip_configurations'] = []
           network_gateway.ip_configurations.each do |ip_config|
-            ip_configuration = FrontendIPConfiguration.new
-            hash['ip_configurations'] << ip_configuration.merge_attributes(FrontendIPConfiguration.parse(ip_config))
+            ip_configuration = Fog::Network::AzureRM::FrontendIPConfiguration.new
+            hash['ip_configurations'] << ip_configuration.merge_attributes(Fog::Network::AzureRM::FrontendIPConfiguration.parse(ip_config))
           end unless network_gateway.ip_configurations.nil?
 
           unless network_gateway.vpn_client_configuration.nil?
-            vpn_client_configuration = VpnClientConfiguration.new
-            hash['vpn_client_configuration'] = vpn_client_configuration.merge_attributes(VpnClientConfiguration.parse(network_gateway.vpn_client_configuration))
+            vpn_client_configuration = Fog::Network::AzureRM::VpnClientConfiguration.new
+            hash['vpn_client_configuration'] = vpn_client_configuration.merge_attributes(Fog::Network::AzureRM::VpnClientConfiguration.parse(network_gateway.vpn_client_configuration))
           end
 
           hash
@@ -68,7 +68,7 @@ module Fog
           requires :name, :location, :resource_group, :gateway_type, :enable_bgp
           validate_ip_configurations(ip_configurations) unless ip_configurations.nil?
           network_gateway = service.create_or_update_virtual_network_gateway(virtual_gateway_parameters)
-          merge_attributes(VirtualNetworkGateway.parse(network_gateway))
+          merge_attributes(Fog::Network::AzureRM::VirtualNetworkGateway.parse(network_gateway))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/virtual_network_gateway_connection.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateway_connection.rb
@@ -27,13 +27,13 @@ module Fog
           connection = get_hash_from_object(gateway_connection)
 
           unless gateway_connection.virtual_network_gateway1.nil?
-            gateway1 = VirtualNetworkGateway.new
-            connection['virtual_network_gateway1'] = gateway1.merge_attributes(VirtualNetworkGateway.parse(gateway_connection.virtual_network_gateway1))
+            gateway1 = Fog::Network::AzureRM::VirtualNetworkGateway.new
+            connection['virtual_network_gateway1'] = gateway1.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGateway.parse(gateway_connection.virtual_network_gateway1))
           end
 
           unless gateway_connection.virtual_network_gateway2.nil?
-            gateway2 = VirtualNetworkGateway.new
-            connection['virtual_network_gateway2'] = gateway2.merge_attributes(VirtualNetworkGateway.parse(gateway_connection.virtual_network_gateway2))
+            gateway2 = Fog::Network::AzureRM::VirtualNetworkGateway.new
+            connection['virtual_network_gateway2'] = gateway2.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGateway.parse(gateway_connection.virtual_network_gateway2))
           end
           connection['resource_group'] = get_resource_group_from_id(gateway_connection.id)
           connection
@@ -42,7 +42,7 @@ module Fog
         def save
           requires :name, :location, :resource_group, :connection_type
           gateway_connection = service.create_or_update_virtual_network_gateway_connection(gateway_connection_parameters)
-          merge_attributes(VirtualNetworkGatewayConnection.parse(gateway_connection))
+          merge_attributes(Fog::Network::AzureRM::VirtualNetworkGatewayConnection.parse(gateway_connection))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/network/virtual_network_gateway_connections.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateway_connections.rb
@@ -3,19 +3,19 @@ module Fog
     class AzureRM
       # VirtualNetworkGatewayConnections collection class for Network Service
       class VirtualNetworkGatewayConnections < Fog::Collection
-        model VirtualNetworkGatewayConnection
+        model Fog::Network::AzureRM::VirtualNetworkGatewayConnection
         attribute :resource_group
 
         def all
           requires :resource_group
-          gateway_connections = service.list_virtual_network_gateway_connections(resource_group).map { |connection| VirtualNetworkGatewayConnection.parse(connection) }
+          gateway_connections = service.list_virtual_network_gateway_connections(resource_group).map { |connection| Fog::Network::AzureRM::VirtualNetworkGatewayConnection.parse(connection) }
           load(gateway_connections)
         end
 
         def get(resource_group_name, name)
           connection = service.get_virtual_network_gateway_connection(resource_group_name, name)
-          gateway_connection = VirtualNetworkGatewayConnection.new(service: service)
-          gateway_connection.merge_attributes(VirtualNetworkGatewayConnection.parse(connection))
+          gateway_connection = Fog::Network::AzureRM::VirtualNetworkGatewayConnection.new(service: service)
+          gateway_connection.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGatewayConnection.parse(connection))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_network_gateways.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateways.rb
@@ -3,22 +3,22 @@ module Fog
     class AzureRM
       # VirtualNetworkGateways collection class for Network Service
       class VirtualNetworkGateways < Fog::Collection
-        model VirtualNetworkGateway
+        model Fog::Network::AzureRM::VirtualNetworkGateway
         attribute :resource_group
 
         def all
           requires :resource_group
           network_gateways = []
           service.list_virtual_network_gateways(resource_group).each do |gateway|
-            network_gateways << VirtualNetworkGateway.parse(gateway)
+            network_gateways << Fog::Network::AzureRM::VirtualNetworkGateway.parse(gateway)
           end
           load(network_gateways)
         end
 
         def get(resource_group_name, name)
           network_gateway = service.get_virtual_network_gateway(resource_group_name, name)
-          virtual_network_gateway = VirtualNetworkGateway.new(service: service)
-          virtual_network_gateway.merge_attributes(VirtualNetworkGateway.parse(network_gateway))
+          virtual_network_gateway = Fog::Network::AzureRM::VirtualNetworkGateway.new(service: service)
+          virtual_network_gateway.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGateway.parse(network_gateway))
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_networks.rb
+++ b/lib/fog/azurerm/models/network/virtual_networks.rb
@@ -4,22 +4,22 @@ module Fog
       # This class is giving implementation of all/list, get and
       # check name availability for virtual network.
       class VirtualNetworks < Fog::Collection
-        model VirtualNetwork
+        model Fog::Network::AzureRM::VirtualNetwork
         attribute :resource_group
 
         def all
           requires :resource_group
           virtual_networks = []
           service.list_virtual_networks(resource_group).each do |vnet|
-            virtual_networks << VirtualNetwork.parse(vnet)
+            virtual_networks << Fog::Network::AzureRM::VirtualNetwork.parse(vnet)
           end
           load(virtual_networks)
         end
 
         def get(resource_group_name, virtual_network_name)
           virtual_network = service.get_virtual_network(resource_group_name, virtual_network_name)
-          virtual_network_fog = VirtualNetwork.new(service: service)
-          virtual_network_fog.merge_attributes(VirtualNetwork.parse(virtual_network))
+          virtual_network_fog = Fog::Network::AzureRM::VirtualNetwork.new(service: service)
+          virtual_network_fog.merge_attributes(Fog::Network::AzureRM::VirtualNetwork.parse(virtual_network))
         end
 
         def check_if_exists(resource_group, name)

--- a/lib/fog/azurerm/models/resources/azure_resources.rb
+++ b/lib/fog/azurerm/models/resources/azure_resources.rb
@@ -5,13 +5,13 @@ module Fog
       class AzureResources < Fog::Collection
         attribute :tag_name
         attribute :tag_value
-        model AzureResource
+        model Fog::Resources::AzureRM::AzureResource
 
         def all
           unless tag_name.nil? && tag_value.nil?
             resources = []
             service.list_tagged_resources(tag_name, tag_value).each do |resource|
-              resources << AzureResource.parse(resource)
+              resources << Fog::Resources::AzureRM::AzureResource.parse(resource)
             end
             resources.inspect
             return load(resources)

--- a/lib/fog/azurerm/models/resources/deployments.rb
+++ b/lib/fog/azurerm/models/resources/deployments.rb
@@ -4,21 +4,21 @@ module Fog
       # Deployments collection class
       class Deployments < Fog::Collection
         attribute :resource_group
-        model Deployment
+        model Fog::Resources::AzureRM::Deployment
 
         def all
           requires :resource_group
           deployments = []
           service.list_deployments(resource_group).each do |deployment|
-            deployments << Deployment.parse(deployment)
+            deployments << Fog::Resources::AzureRM::Deployment.parse(deployment)
           end
           load(deployments)
         end
 
         def get(resource_group_name, deployment_name)
           deployment = service.get_deployment(resource_group_name, deployment_name)
-          deployment_fog = Deployment.new(service: service)
-          deployment_fog.merge_attributes(Deployment.parse(deployment))
+          deployment_fog = Fog::Resources::AzureRM::Deployment.new(service: service)
+          deployment_fog.merge_attributes(Fog::Resources::AzureRM::Deployment.parse(deployment))
         end
       end
     end

--- a/lib/fog/azurerm/models/resources/resource_groups.rb
+++ b/lib/fog/azurerm/models/resources/resource_groups.rb
@@ -4,20 +4,20 @@ module Fog
       # This class is giving implementation of all/list, get and
       # check name availability for resource groups.
       class ResourceGroups < Fog::Collection
-        model ResourceGroup
+        model Fog::Resources::AzureRM::ResourceGroup
 
         def all
           resource_groups = []
           service.list_resource_groups.each do |resource_group|
-            resource_groups.push(ResourceGroup.parse(resource_group))
+            resource_groups.push(Fog::Resources::AzureRM::ResourceGroup.parse(resource_group))
           end
           load(resource_groups)
         end
 
         def get(resource_group_name)
           resource_group = service.get_resource_group(resource_group_name)
-          resource_group_fog = ResourceGroup.new(service: service)
-          resource_group_fog.merge_attributes(ResourceGroup.parse(resource_group))
+          resource_group_fog = Fog::Resources::AzureRM::ResourceGroup.new(service: service)
+          resource_group_fog.merge_attributes(Fog::Resources::AzureRM::ResourceGroup.parse(resource_group))
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/firewall_rule.rb
+++ b/lib/fog/azurerm/models/sql/firewall_rule.rb
@@ -28,7 +28,7 @@ module Fog
         def save
           requires :resource_group, :server_name, :name, :start_ip, :end_ip
           firewall_rule = service.create_or_update_firewall_rule(firewall_params)
-          merge_attributes(FirewallRule.parse(firewall_rule))
+          merge_attributes(Fog::Sql::AzureRM::FirewallRule.parse(firewall_rule))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/sql/firewall_rules.rb
+++ b/lib/fog/azurerm/models/sql/firewall_rules.rb
@@ -5,22 +5,22 @@ module Fog
       class FirewallRules < Fog::Collection
         attribute :resource_group
         attribute :server_name
-        model FirewallRule
+        model Fog::Sql::AzureRM::FirewallRule
 
         def all
           requires :resource_group, :server_name
 
           firewall_rules = []
           service.list_firewall_rules(resource_group, server_name).each do |firewall_rule|
-            firewall_rules << FirewallRule.parse(firewall_rule)
+            firewall_rules << Fog::Sql::AzureRM::FirewallRule.parse(firewall_rule)
           end
           load(firewall_rules)
         end
 
         def get(resource_group, server_name, rule_name)
           firewall_rule = service.get_firewall_rule(resource_group, server_name, rule_name)
-          firewall_rule_fog = FirewallRule.new(service: service)
-          firewall_rule_fog.merge_attributes(FirewallRule.parse(firewall_rule))
+          firewall_rule_fog = Fog::Sql::AzureRM::FirewallRule.new(service: service)
+          firewall_rule_fog.merge_attributes(Fog::Sql::AzureRM::FirewallRule.parse(firewall_rule))
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/sql_database.rb
+++ b/lib/fog/azurerm/models/sql/sql_database.rb
@@ -60,7 +60,7 @@ module Fog
         def save
           requires :resource_group, :server_name, :name, :location
           sql_database = service.create_or_update_database(database_params)
-          merge_attributes(SqlDatabase.parse(sql_database))
+          merge_attributes(Fog::Sql::AzureRM::SqlDatabase.parse(sql_database))
         end
 
         def destroy

--- a/lib/fog/azurerm/models/sql/sql_databases.rb
+++ b/lib/fog/azurerm/models/sql/sql_databases.rb
@@ -5,22 +5,22 @@ module Fog
       class SqlDatabases < Fog::Collection
         attribute :resource_group
         attribute :server_name
-        model SqlDatabase
+        model Fog::Sql::AzureRM::SqlDatabase
 
         def all
           requires :resource_group, :server_name
 
           databases = []
           service.list_databases(resource_group, server_name).each do |database|
-            databases << SqlDatabase.parse(database)
+            databases << Fog::Sql::AzureRM::SqlDatabase.parse(database)
           end
           load(databases)
         end
 
         def get(resource_group, server_name, name)
           database = service.get_database(resource_group, server_name, name)
-          database_fog = SqlDatabase.new(service: service)
-          database_fog.merge_attributes(SqlDatabase.parse(database))
+          database_fog = Fog::Sql::AzureRM::SqlDatabase.new(service: service)
+          database_fog.merge_attributes(Fog::Sql::AzureRM::SqlDatabase.parse(database))
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/sql_servers.rb
+++ b/lib/fog/azurerm/models/sql/sql_servers.rb
@@ -4,22 +4,22 @@ module Fog
       # Sql Server Collection for Server Service
       class SqlServers < Fog::Collection
         attribute :resource_group
-        model SqlServer
+        model Fog::Sql::AzureRM::SqlServer
 
         def all
           requires :resource_group
 
           servers = []
           service.list_sql_servers(resource_group).each do |server|
-            servers << SqlServer.parse(server)
+            servers << Fog::Sql::AzureRM::SqlServer.parse(server)
           end
           load(servers)
         end
 
         def get(resource_group, server_name)
           server = service.get_sql_server(resource_group, server_name)
-          server_fog = SqlServer.new(service: service)
-          server_fog.merge_attributes(SqlServer.parse(server))
+          server_fog = Fog::Sql::AzureRM::SqlServer.new(service: service)
+          server_fog.merge_attributes(Fog::Sql::AzureRM::SqlServer.parse(server))
         end
       end
     end

--- a/lib/fog/azurerm/models/storage/directories.rb
+++ b/lib/fog/azurerm/models/storage/directories.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class is giving implementation of listing containers.
       class Directories < Fog::Collection
-        model Directory
+        model Fog::Storage::AzureRM::Directory
 
         def all(options = { metadata: true })
           containers = []

--- a/lib/fog/azurerm/models/storage/directory.rb
+++ b/lib/fog/azurerm/models/storage/directory.rb
@@ -14,19 +14,19 @@ module Fog
 
         def create(options = {})
           requires :key
-          merge_attributes(Directory.parse(service.create_container(key, options)))
+          merge_attributes(Fog::Storage::AzureRM::Directory.parse(service.create_container(key, options)))
         end
 
         alias save create
 
         def get_properties(options = { metadata: true })
           requires :key
-          merge_attributes(Directory.parse(service.get_container_properties(key, options)))
+          merge_attributes(Fog::Storage::AzureRM::Directory.parse(service.get_container_properties(key, options)))
         end
 
         def access_control_list(options = {})
           requires :key
-          merge_attributes(Directory.parse(service.get_container_access_control_list(key, options)[0]))
+          merge_attributes(Fog::Storage::AzureRM::Directory.parse(service.get_container_access_control_list(key, options)[0]))
         end
 
         def destroy(options = {})

--- a/lib/fog/azurerm/models/storage/file.rb
+++ b/lib/fog/azurerm/models/storage/file.rb
@@ -35,7 +35,7 @@ module Fog
           requires :key
           requires :directory
           merge_attributes(options)
-          merge_attributes(File.parse(service.upload_block_blob_from_file(directory, key, file_path, options)))
+          merge_attributes(Fog::Storage::AzureRM::File.parse(service.upload_block_blob_from_file(directory, key, file_path, options)))
         end
 
         alias create save
@@ -50,13 +50,13 @@ module Fog
           requires :key
           requires :directory
           merge_attributes(file_path: file_path)
-          merge_attributes(File.parse(service.download_blob_to_file(directory, key, file_path, options)))
+          merge_attributes(Fog::Storage::AzureRM::File.parse(service.download_blob_to_file(directory, key, file_path, options)))
         end
 
         def get_properties(options = {})
           requires :key
           requires :directory
-          merge_attributes(File.parse(service.get_blob_properties(directory, key, options)))
+          merge_attributes(Fog::Storage::AzureRM::File.parse(service.get_blob_properties(directory, key, options)))
         end
 
         def set_properties(properties = {})

--- a/lib/fog/azurerm/models/storage/files.rb
+++ b/lib/fog/azurerm/models/storage/files.rb
@@ -3,13 +3,13 @@ module Fog
     class AzureRM
       # This class is giving implementation of listing blobs.
       class Files < Fog::Collection
-        model File
+        model Fog::Storage::AzureRM::File
         attribute :directory
 
         def all(options = { metadata: true })
           files = []
           service.list_blobs(directory, options).each do |blob|
-            hash = File.parse blob
+            hash = Fog::Storage::AzureRM::File.parse blob
             hash['directory'] = directory
             files << hash
           end
@@ -17,7 +17,7 @@ module Fog
         end
 
         def get(directory, name)
-          file = File.new(service: service)
+          file = Fog::Storage::AzureRM::File.new(service: service)
           file.directory = directory
           file.key = name
           file

--- a/lib/fog/azurerm/models/storage/recovery_vault.rb
+++ b/lib/fog/azurerm/models/storage/recovery_vault.rb
@@ -25,7 +25,7 @@ module Fog
         def save
           requires :name, :location, :resource_group
           recovery_vault = service.create_or_update_recovery_vault(resource_group, location, name)
-          merge_attributes(RecoveryVault.parse(recovery_vault))
+          merge_attributes(Fog::Storage::AzureRM::RecoveryVault.parse(recovery_vault))
         end
 
         def enable_backup_protection(vm_name, vm_resource_group)

--- a/lib/fog/azurerm/models/storage/recovery_vaults.rb
+++ b/lib/fog/azurerm/models/storage/recovery_vaults.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class is giving implementation of all/get for Recovery Vaults
       class RecoveryVaults < Fog::Collection
-        model RecoveryVault
+        model Fog::Storage::AzureRM::RecoveryVault
         attribute :resource_group
         attribute :name
 
@@ -11,15 +11,15 @@ module Fog
           requires :resource_group
           recovery_vaults = []
           service.list_recovery_vaults(resource_group).each do |recovery_vault|
-            recovery_vaults << RecoveryVault.parse(recovery_vault)
+            recovery_vaults << Fog::Storage::AzureRM::RecoveryVault.parse(recovery_vault)
           end
           load(recovery_vaults)
         end
 
         def get(resource_group, name)
           recovery_vault = service.get_recovery_vault(resource_group, name)
-          recovery_vault_fog = RecoveryVault.new(service: service)
-          recovery_vault_fog.merge_attributes(RecoveryVault.parse(recovery_vault))
+          recovery_vault_fog = Fog::Storage::AzureRM::RecoveryVault.new(service: service)
+          recovery_vault_fog.merge_attributes(Fog::Storage::AzureRM::RecoveryVault.parse(recovery_vault))
         end
       end
     end

--- a/lib/fog/azurerm/models/storage/storage_account.rb
+++ b/lib/fog/azurerm/models/storage/storage_account.rb
@@ -33,7 +33,7 @@ module Fog
           self.replication = ALLOWED_STANDARD_REPLICATION.first if replication.nil?
           validate_sku_name!
           storage_account = service.create_storage_account(storage_account_params)
-          merge_attributes(StorageAccount.parse(storage_account))
+          merge_attributes(Fog::Storage::AzureRM::StorageAccount.parse(storage_account))
         end
 
         def storage_account_params
@@ -52,7 +52,7 @@ module Fog
           storage_account_params = merge_attributes(storage_account_params).all_attributes
 
           storage_account = service.update_storage_account(storage_account_params)
-          merge_attributes(StorageAccount.parse(storage_account))
+          merge_attributes(Fog::Storage::AzureRM::StorageAccount.parse(storage_account))
         end
 
         def validate_sku_name!

--- a/lib/fog/azurerm/models/storage/storage_accounts.rb
+++ b/lib/fog/azurerm/models/storage/storage_accounts.rb
@@ -4,7 +4,7 @@ module Fog
       # This class is giving implementation of all/list, get and
       # check name availability for storage account.
       class StorageAccounts < Fog::Collection
-        model StorageAccount
+        model Fog::Storage::AzureRM::StorageAccount
         attribute :resource_group
 
         def all
@@ -16,15 +16,15 @@ module Fog
             hash_of_storage_accounts = service.list_storage_accounts
           end
           hash_of_storage_accounts.each do |account|
-            accounts << StorageAccount.parse(account)
+            accounts << Fog::Storage::AzureRM::StorageAccount.parse(account)
           end
           load(accounts)
         end
 
         def get(resource_group_name, storage_account_name)
           storage_account = service.get_storage_account(resource_group_name, storage_account_name)
-          storage_account_fog = StorageAccount.new(service: service)
-          storage_account_fog.merge_attributes(StorageAccount.parse(storage_account))
+          storage_account_fog = Fog::Storage::AzureRM::StorageAccount.new(service: service)
+          storage_account_fog.merge_attributes(Fog::Storage::AzureRM::StorageAccount.parse(storage_account))
         end
 
         def check_name_availability(name)

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_point.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_point.rb
@@ -50,7 +50,7 @@ module Fog
         def create_or_update
           if %w(azureEndpoints externalEndpoints nestedEndpoints).select { |type| type if type.eql?(type) }.any?
             traffic_manager_endpoint = service.create_or_update_traffic_manager_endpoint(traffic_manager_endpoint_hash)
-            merge_attributes(TrafficManagerEndPoint.parse(traffic_manager_endpoint))
+            merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.parse(traffic_manager_endpoint))
           else
             raise(ArgumentError, ":type should be '#{AZURE_ENDPOINTS}', '#{EXTERNAL_ENDPOINTS}' or '#{NESTED_ENDPOINTS}'")
           end

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_points.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_points.rb
@@ -5,20 +5,20 @@ module Fog
       class TrafficManagerEndPoints < Fog::Collection
         attribute :resource_group
         attribute :traffic_manager_profile_name
-        model TrafficManagerEndPoint
+        model Fog::TrafficManager::AzureRM::TrafficManagerEndPoint
 
         def all
           requires :resource_group, :traffic_manager_profile_name
 
           end_points = service.get_traffic_manager_profile(resource_group, traffic_manager_profile_name).endpoints
-          traffic_manager_endpoints = end_points.map { |endpoint| TrafficManagerEndPoint.parse(endpoint) }
+          traffic_manager_endpoints = end_points.map { |endpoint| Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.parse(endpoint) }
           load(traffic_manager_endpoints)
         end
 
         def get(resource_group, traffic_manager_profile_name, end_point_name, type)
           endpoint = service.get_traffic_manager_end_point(resource_group, traffic_manager_profile_name, end_point_name, type)
-          endpoint_fog = TrafficManagerEndPoint.new(service: service)
-          endpoint_fog.merge_attributes(TrafficManagerEndPoint.parse(endpoint))
+          endpoint_fog = Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.new(service: service)
+          endpoint_fog.merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.parse(endpoint))
         end
       end
     end

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_profile.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_profile.rb
@@ -36,8 +36,8 @@ module Fog
           traffic_manager_profile['resource_group'] = get_resource_group_from_id(profile.id)
           traffic_manager_profile['endpoints'] = []
           profile.endpoints.each do |endpoint|
-            end_point = TrafficManagerEndPoint.new
-            traffic_manager_profile['endpoints'] << end_point.merge_attributes(TrafficManagerEndPoint.parse(endpoint))
+            end_point = Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.new
+            traffic_manager_profile['endpoints'] << end_point.merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.parse(endpoint))
           end
           traffic_manager_profile
         end
@@ -46,7 +46,7 @@ module Fog
           requires :name, :resource_group, :traffic_routing_method, :relative_name, :ttl,
                    :protocol, :port, :path
           traffic_manager_profile = service.create_or_update_traffic_manager_profile(traffic_manager_profile_hash)
-          merge_attributes(TrafficManagerProfile.parse(traffic_manager_profile))
+          merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerProfile.parse(traffic_manager_profile))
         end
 
         def destroy
@@ -57,7 +57,7 @@ module Fog
           validate_input(profile_params)
           merge_attributes(profile_params)
           profile = service.create_or_update_traffic_manager_profile(traffic_manager_profile_hash)
-          merge_attributes(TrafficManagerProfile.parse(profile))
+          merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerProfile.parse(profile))
         end
 
         private

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_profiles.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_profiles.rb
@@ -4,18 +4,18 @@ module Fog
       # Traffic Manager Profile Collection for TrafficManager Service
       class TrafficManagerProfiles < Fog::Collection
         attribute :resource_group
-        model TrafficManagerProfile
+        model Fog::TrafficManager::AzureRM::TrafficManagerProfile
 
         def all
           requires :resource_group
-          traffic_manager_profiles = service.list_traffic_manager_profiles(resource_group).map { |profile| TrafficManagerProfile.parse(profile) }
+          traffic_manager_profiles = service.list_traffic_manager_profiles(resource_group).map { |profile| Fog::TrafficManager::AzureRM::TrafficManagerProfile.parse(profile) }
           load(traffic_manager_profiles)
         end
 
         def get(resource_group, traffic_manager_profile_name)
           profile = service.get_traffic_manager_profile(resource_group, traffic_manager_profile_name)
-          profile_fog = TrafficManagerProfile.new(service: service)
-          profile_fog.merge_attributes(TrafficManagerProfile.parse(profile))
+          profile_fog = Fog::TrafficManager::AzureRM::TrafficManagerProfile.new(service: service)
+          profile_fog.merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerProfile.parse(profile))
         end
       end
     end

--- a/test/api_stub/models/application_gateway/gateway.rb
+++ b/test/api_stub/models/application_gateway/gateway.rb
@@ -129,7 +129,7 @@ module ApiStub
               }
             }'
           gateway_mapper = Azure::ARM::Network::Models::ApplicationGateway.mapper
-          gateway_client.deserialize(gateway_mapper, JSON.load(gateway), 'result.body')
+          gateway_client.deserialize(gateway_mapper, Fog::JSON.decode(gateway), 'result.body')
         end
 
         def self.ssl_certifcate

--- a/test/api_stub/models/compute/server.rb
+++ b/test/api_stub/models/compute/server.rb
@@ -121,7 +121,7 @@ module ApiStub
             ]
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachineSizeListResult.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body').value
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body').value
         end
 
         def self.attach_data_disk_response(compute_client)

--- a/test/api_stub/models/dns/record_set.rb
+++ b/test/api_stub/models/dns/record_set.rb
@@ -27,7 +27,7 @@ module ApiStub
               }
           }'
           record_set_mapper = Azure::ARM::Dns::Models::RecordSet.mapper
-          dns_client.deserialize(record_set_mapper, JSON.load(record_set), 'result.body')
+          dns_client.deserialize(record_set_mapper, Fog::JSON.decode(record_set), 'result.body')
         end
 
         def self.response_for_cname(dns_client)
@@ -49,7 +49,7 @@ module ApiStub
             }
           }'
           cname_record_mapper = Azure::ARM::Dns::Models::RecordSet.mapper
-          dns_client.deserialize(cname_record_mapper, JSON.load(cname_record), 'result.body')
+          dns_client.deserialize(cname_record_mapper, Fog::JSON.decode(cname_record), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/dns/zone.rb
+++ b/test/api_stub/models/dns/zone.rb
@@ -21,7 +21,7 @@ module ApiStub
             "resource_group": "fog-test-rg"
           }'
           zone_mapper = Azure::ARM::Dns::Models::Zone.mapper
-          dns_client.deserialize(zone_mapper, JSON.load(zone), 'result.body')
+          dns_client.deserialize(zone_mapper, Fog::JSON.decode(zone), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/express_route_circuit.rb
+++ b/test/api_stub/models/network/express_route_circuit.rb
@@ -39,7 +39,7 @@ module ApiStub
             }
           }'
           express_route_circuit_mapper = Azure::ARM::Network::Models::ExpressRouteCircuit.mapper
-          network_client.deserialize(express_route_circuit_mapper, JSON.load(circuit), 'result.body')
+          network_client.deserialize(express_route_circuit_mapper, Fog::JSON.decode(circuit), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/express_route_circuit_authorization.rb
+++ b/test/api_stub/models/network/express_route_circuit_authorization.rb
@@ -14,7 +14,7 @@ module ApiStub
           }'
 
           express_route_circuit_authorization_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitAuthorization.mapper
-          network_client.deserialize(express_route_circuit_authorization_mapper, JSON.load(authorization), 'result.body')
+          network_client.deserialize(express_route_circuit_authorization_mapper, Fog::JSON.decode(authorization), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/express_route_circuit_peering.rb
+++ b/test/api_stub/models/network/express_route_circuit_peering.rb
@@ -25,7 +25,7 @@ module ApiStub
                           }
                   }'
           express_route_circuit_peering_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitPeering.mapper
-          network_client.deserialize(express_route_circuit_peering_mapper, JSON.load(peering), 'result.body')
+          network_client.deserialize(express_route_circuit_peering_mapper, Fog::JSON.decode(peering), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/express_route_service_provider.rb
+++ b/test/api_stub/models/network/express_route_service_provider.rb
@@ -21,7 +21,7 @@ module ApiStub
               }
             ]}'
           express_route_servcie_provider_mapper = Azure::ARM::Network::Models::ExpressRouteServiceProviderListResult.mapper
-          network_client.deserialize(express_route_servcie_provider_mapper, JSON.load(service_provider), 'result.body').value
+          network_client.deserialize(express_route_servcie_provider_mapper, Fog::JSON.decode(service_provider), 'result.body').value
         end
       end
     end

--- a/test/api_stub/models/network/load_balancer.rb
+++ b/test/api_stub/models/network/load_balancer.rb
@@ -146,7 +146,7 @@ module ApiStub
 						}
           }'
           load_balancer_mapper = Azure::ARM::Network::Models::LoadBalancer.mapper
-          network_client.deserialize(load_balancer_mapper, JSON.load(load_balancer), 'result.body')
+          network_client.deserialize(load_balancer_mapper, Fog::JSON.decode(load_balancer), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/network_interface.rb
+++ b/test/api_stub/models/network/network_interface.rb
@@ -64,7 +64,7 @@ module ApiStub
              }
           }'
           network_interface_mapper = Azure::ARM::Network::Models::NetworkInterface.mapper
-          network_client.deserialize(network_interface_mapper, JSON.load(nic), 'result.body')
+          network_client.deserialize(network_interface_mapper, Fog::JSON.decode(nic), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/network_security_group.rb
+++ b/test/api_stub/models/network/network_security_group.rb
@@ -69,7 +69,7 @@ module ApiStub
              }
           }'
           result_mapper = Azure::ARM::Network::Models::NetworkSecurityGroup.mapper
-          network_client.deserialize(result_mapper, JSON.load(nsg), 'result.body')
+          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg), 'result.body')
         end
 
         def self.security_rules_array

--- a/test/api_stub/models/network/network_security_rule.rb
+++ b/test/api_stub/models/network/network_security_rule.rb
@@ -22,7 +22,7 @@ module ApiStub
               }
           }'
           nsr_mapper = Azure::ARM::Network::Models::SecurityRule.mapper
-          network_client.deserialize(nsr_mapper, JSON.load(nsr), 'result.body')
+          network_client.deserialize(nsr_mapper, Fog::JSON.decode(nsr), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/public_ip.rb
+++ b/test/api_stub/models/network/public_ip.rb
@@ -28,7 +28,7 @@ module ApiStub
              }
           }'
           public_ip_mapper = Azure::ARM::Network::Models::PublicIPAddress.mapper
-          network_client.deserialize(public_ip_mapper, JSON.load(public_ip), 'result.body')
+          network_client.deserialize(public_ip_mapper, Fog::JSON.decode(public_ip), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/subnet.rb
+++ b/test/api_stub/models/network/subnet.rb
@@ -28,7 +28,7 @@ module ApiStub
              }
           }'
           subnet_mapper = Azure::ARM::Network::Models::Subnet.mapper
-          network_client.deserialize(subnet_mapper, JSON.load(subnet), 'result.body')
+          network_client.deserialize(subnet_mapper, Fog::JSON.decode(subnet), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/virtual_network.rb
+++ b/test/api_stub/models/network/virtual_network.rb
@@ -54,7 +54,7 @@ module ApiStub
              }
           }'
           vnet_mapper = Azure::ARM::Network::Models::VirtualNetwork.mapper
-          network_client.deserialize(vnet_mapper, JSON.load(vnet), 'result.body')
+          network_client.deserialize(vnet_mapper, Fog::JSON.decode(vnet), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/virtual_network_gateway.rb
+++ b/test/api_stub/models/network/virtual_network_gateway.rb
@@ -18,7 +18,7 @@ module ApiStub
             }
           }'
           gateway_mapper = Azure::ARM::Network::Models::VirtualNetworkGateway.mapper
-          network_client.deserialize(gateway_mapper, JSON.load(network_gateway), 'result.body')
+          network_client.deserialize(gateway_mapper, Fog::JSON.decode(network_gateway), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/network/virtual_network_gateway_connection.rb
+++ b/test/api_stub/models/network/virtual_network_gateway_connection.rb
@@ -23,7 +23,7 @@ module ApiStub
             }
           }'
           connection_mapper = Azure::ARM::Network::Models::VirtualNetworkGatewayConnection.mapper
-          network_client.deserialize(connection_mapper, JSON.load(gateway_connection), 'result.body')
+          network_client.deserialize(connection_mapper, Fog::JSON.decode(gateway_connection), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/resources/resource.rb
+++ b/test/api_stub/models/resources/resource.rb
@@ -16,7 +16,7 @@ module ApiStub
                 "name": "free"
             }
           }'
-          JSON.load(body)
+          Fog::JSON.decode(body)
         end
 
         def self.list_resources_response(client)
@@ -35,7 +35,7 @@ module ApiStub
             }]
           }'
           result_mapper = Azure::ARM::Resources::Models::ResourceListResult.mapper
-          client.deserialize(result_mapper, JSON.load(resources), 'result.body').value
+          client.deserialize(result_mapper, Fog::JSON.decode(resources), 'result.body').value
         end
       end
     end

--- a/test/api_stub/models/resources/resource_group.rb
+++ b/test/api_stub/models/resources/resource_group.rb
@@ -16,7 +16,7 @@ module ApiStub
             }
           }'
           result_mapper = Azure::ARM::Resources::Models::ResourceGroup.mapper
-          client.deserialize(result_mapper, JSON.load(resource_group), 'result.body')
+          client.deserialize(result_mapper, Fog::JSON.decode(resource_group), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/traffic_manager/traffic_manager_end_point.rb
+++ b/test/api_stub/models/traffic_manager/traffic_manager_end_point.rb
@@ -19,7 +19,7 @@ module ApiStub
             }
           }'
           endpoint_mapper = Azure::ARM::TrafficManager::Models::Endpoint.mapper
-          traffic_manager_client.deserialize(endpoint_mapper, JSON.load(endpoint), 'result.body')
+          traffic_manager_client.deserialize(endpoint_mapper, Fog::JSON.decode(endpoint), 'result.body')
         end
       end
     end

--- a/test/api_stub/models/traffic_manager/traffic_manager_profile.rb
+++ b/test/api_stub/models/traffic_manager/traffic_manager_profile.rb
@@ -67,7 +67,7 @@ module ApiStub
             }
           }'
           profile_mapper = Azure::ARM::TrafficManager::Models::Profile.mapper
-          traffic_manager_client.deserialize(profile_mapper, JSON.load(profile), 'result.body')
+          traffic_manager_client.deserialize(profile_mapper, Fog::JSON.decode(profile), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/application_gateway/gateway.rb
+++ b/test/api_stub/requests/application_gateway/gateway.rb
@@ -136,7 +136,7 @@ module ApiStub
             }
           }'
           gateway_mapper = Azure::ARM::Network::Models::ApplicationGateway.mapper
-          gateway_client.deserialize(gateway_mapper, JSON.load(response), 'result.body')
+          gateway_client.deserialize(gateway_mapper, Fog::JSON.decode(response), 'result.body')
         end
 
         def self.gateway_params
@@ -303,7 +303,7 @@ module ApiStub
             }]
           }'
           gateway_list_mapper = Azure::ARM::Network::Models::ApplicationGatewayListResult.mapper
-          gateway_client.deserialize(gateway_list_mapper, JSON.load(response), 'result.body')
+          gateway_client.deserialize(gateway_list_mapper, Fog::JSON.decode(response), 'result.body')
         end
 
         def self.delete_application_gateway_response

--- a/test/api_stub/requests/compute/availability_set.rb
+++ b/test/api_stub/requests/compute/availability_set.rb
@@ -15,7 +15,7 @@ module ApiStub
                     "virtualMachines":[]
                   }'
           availability_set_mapper = Azure::ARM::Compute::Models::AvailabilitySet.mapper
-          compute_client.deserialize(availability_set_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(availability_set_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_availability_set_response(sdk_compute_client)
@@ -32,7 +32,7 @@ module ApiStub
               } ]
           }'
           availability_set_mapper = Azure::ARM::Compute::Models::AvailabilitySetListResult.mapper
-          sdk_compute_client.deserialize(availability_set_mapper, JSON.load(body), 'result.body')
+          sdk_compute_client.deserialize(availability_set_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.get_availability_set_response(sdk_compute_client)
@@ -49,7 +49,7 @@ module ApiStub
               } ]
           }'
           availability_set_mapper = Azure::ARM::Compute::Models::AvailabilitySet.mapper
-          sdk_compute_client.deserialize(availability_set_mapper, JSON.load(body), 'result.body')
+          sdk_compute_client.deserialize(availability_set_mapper, Fog::JSON.decode(body), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/compute/virtual_machine.rb
+++ b/test/api_stub/requests/compute/virtual_machine.rb
@@ -217,7 +217,7 @@ module ApiStub
             }
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.create_virtual_machine_with_custom_data_response(compute_client)
@@ -294,7 +294,7 @@ module ApiStub
             }
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.create_virtual_machine_from_custom_image_response(compute_client)
@@ -371,7 +371,7 @@ module ApiStub
             }
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.detach_data_disk_from_vm_response(compute_client)
@@ -440,7 +440,7 @@ module ApiStub
             }
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.virtual_machine_response(compute_client)
@@ -627,7 +627,7 @@ module ApiStub
             ]
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachineListResult.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_available_sizes_for_virtual_machine_response(compute_client)
@@ -644,7 +644,7 @@ module ApiStub
             ]
           }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachineSizeListResult.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.virtual_machine_instance_view_response(compute_client)
@@ -701,7 +701,7 @@ module ApiStub
               }
             }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.vm_status_response
@@ -792,7 +792,7 @@ module ApiStub
                 }
               }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.virtual_machine_15_data_disks_response(compute_client)
@@ -935,7 +935,7 @@ module ApiStub
                 }
               }'
           vm_mapper = Azure::ARM::Compute::Models::VirtualMachine.mapper
-          compute_client.deserialize(vm_mapper, JSON.load(body), 'result.body')
+          compute_client.deserialize(vm_mapper, Fog::JSON.decode(body), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/dns/record_set.rb
+++ b/test/api_stub/requests/dns/record_set.rb
@@ -22,7 +22,7 @@ module ApiStub
           }]
           }'
           record_set_mapper = Azure::ARM::Dns::Models::RecordSetListResult.mapper
-          dns_client.deserialize(record_set_mapper, JSON.load(body), 'result.body').value
+          dns_client.deserialize(record_set_mapper, Fog::JSON.decode(body), 'result.body').value
         end
 
         def self.record_set_response_for_a_type_response(dns_client)
@@ -46,7 +46,7 @@ module ApiStub
             }
           }'
           record_set_mapper = Azure::ARM::Dns::Models::RecordSet.mapper
-          dns_client.deserialize(record_set_mapper, JSON.load(record_set), 'result.body')
+          dns_client.deserialize(record_set_mapper, Fog::JSON.decode(record_set), 'result.body')
         end
 
         def self.record_set_response_for_cname_type(dns_client)
@@ -67,7 +67,7 @@ module ApiStub
             }
           }'
           record_set_mapper = Azure::ARM::Dns::Models::RecordSet.mapper
-          dns_client.deserialize(record_set_mapper, JSON.load(record_set), 'result.body')
+          dns_client.deserialize(record_set_mapper, Fog::JSON.decode(record_set), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/dns/zone.rb
+++ b/test/api_stub/requests/dns/zone.rb
@@ -6,24 +6,24 @@ module ApiStub
         def self.list_zones_response(dns_client)
           body = '{
             "value": [{
-                       "id":"\/subscriptions\/########-####-####-####-############\/resourceGroups\/fog_test_rg\/providers\/Microsoft.Network\/dnszones\/adnaan.com",
-                        "name":"adnaan.com",
-                        "type":"Microsoft.Network\/dnszones",
-                        "etag":"00000011-0000-0000-19f2-3a6c32b0d101",
-                        "location":"global",
-                        "tags":{},
-                        "properties":
-                                    {
-                                        "maxNumberOfRecordSets":5000,
-                                        "nameServers":null,
-                                        "numberOfRecordSets":2,
-                                        "parentResourceGroupName":"fog_test_rg"
-                                    },
-                        "resource_group":"fog-test-rg"
-                        }]
-            }'
+              "id":"\/subscriptions\/########-####-####-####-############\/resourceGroups\/fog_test_rg\/providers\/Microsoft.Network\/dnszones\/adnaan.com",
+              "name":"adnaan.com",
+              "type":"Microsoft.Network\/dnszones",
+              "etag":"00000011-0000-0000-19f2-3a6c32b0d101",
+              "location":"global",
+              "tags":{},
+              "properties":
+                {
+                  "maxNumberOfRecordSets":5000,
+                  "nameServers":null,
+                  "numberOfRecordSets":2,
+                  "parentResourceGroupName":"fog_test_rg"
+                },
+                "resource_group":"fog-test-rg"
+            }]
+          }'
           zone_mapper = Azure::ARM::Dns::Models::ZoneListResult.mapper
-          dns_client.deserialize(zone_mapper, JSON.load(body), 'result.body').value
+          dns_client.deserialize(zone_mapper, Fog::JSON.decode(body), 'result.body').value
         end
 
         def self.zone_response(dns_client)
@@ -44,7 +44,7 @@ module ApiStub
             "resource_group": "fog-test-rg"
           }'
           zone_mapper = Azure::ARM::Dns::Models::Zone.mapper
-          dns_client.deserialize(zone_mapper, JSON.load(zone), 'result.body')
+          dns_client.deserialize(zone_mapper, Fog::JSON.decode(zone), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/network/express_route_circuit.rb
+++ b/test/api_stub/requests/network/express_route_circuit.rb
@@ -39,7 +39,7 @@ module ApiStub
             }
           }'
           express_route_circuit_mapper = Azure::ARM::Network::Models::ExpressRouteCircuit.mapper
-          network_client.deserialize(express_route_circuit_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(express_route_circuit_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_express_route_circuit_response(network_client)
@@ -75,7 +75,7 @@ module ApiStub
             ]
           }'
           express_route_circuit_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitListResult.mapper
-          network_client.deserialize(express_route_circuit_mapper, JSON.load(body), 'result.body').value
+          network_client.deserialize(express_route_circuit_mapper, Fog::JSON.decode(body), 'result.body').value
         end
 
         def self.peerings

--- a/test/api_stub/requests/network/express_route_circuit_authorization.rb
+++ b/test/api_stub/requests/network/express_route_circuit_authorization.rb
@@ -13,7 +13,7 @@ module ApiStub
             }
           }'
           circuit_auth_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitAuthorization.mapper
-          network_client.deserialize(circuit_auth_mapper, JSON.load(authorization), 'result.body')
+          network_client.deserialize(circuit_auth_mapper, Fog::JSON.decode(authorization), 'result.body')
         end
 
         def self.auth_hash

--- a/test/api_stub/requests/network/express_route_circuit_peering.rb
+++ b/test/api_stub/requests/network/express_route_circuit_peering.rb
@@ -25,7 +25,7 @@ module ApiStub
             }
           }'
           express_route_circuit_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitPeering.mapper
-          network_client.deserialize(express_route_circuit_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(express_route_circuit_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_express_route_circuit_peering_response(network_client)
@@ -54,7 +54,7 @@ module ApiStub
             ]
           }'
           express_route_circuit_mapper = Azure::ARM::Network::Models::ExpressRouteCircuitPeeringListResult.mapper
-          network_client.deserialize(express_route_circuit_mapper, JSON.load(body), 'result.body').value
+          network_client.deserialize(express_route_circuit_mapper, Fog::JSON.decode(body), 'result.body').value
         end
       end
     end

--- a/test/api_stub/requests/network/express_route_service_provider.rb
+++ b/test/api_stub/requests/network/express_route_service_provider.rb
@@ -22,7 +22,7 @@ module ApiStub
             ]
           }'
           express_route_servcie_provider_mapper = Azure::ARM::Network::Models::ExpressRouteServiceProviderListResult.mapper
-          network_client.deserialize(express_route_servcie_provider_mapper, JSON.load(service_provider), 'result.body').value
+          network_client.deserialize(express_route_servcie_provider_mapper, Fog::JSON.decode(service_provider), 'result.body').value
         end
       end
     end

--- a/test/api_stub/requests/network/load_balancer.rb
+++ b/test/api_stub/requests/network/load_balancer.rb
@@ -146,7 +146,7 @@ module ApiStub
             }
           }'
           load_balancer_mapper = Azure::ARM::Network::Models::LoadBalancer.mapper
-          network_client.deserialize(load_balancer_mapper, JSON.load(response), 'result.body')
+          network_client.deserialize(load_balancer_mapper, Fog::JSON.decode(response), 'result.body')
         end
 
         def self.list_load_balancers_response(network_client)
@@ -297,7 +297,7 @@ module ApiStub
             ]
           }'
           load_balancer_mapper = Azure::ARM::Network::Models::LoadBalancerListResult.mapper
-          network_client.deserialize(load_balancer_mapper, JSON.load(response), 'result.body')
+          network_client.deserialize(load_balancer_mapper, Fog::JSON.decode(response), 'result.body')
         end
 
         def self.delete_load_balancer_response

--- a/test/api_stub/requests/network/network_interface.rb
+++ b/test/api_stub/requests/network/network_interface.rb
@@ -64,7 +64,7 @@ module ApiStub
             }
           }'
           network_interface_mapper = Azure::ARM::Network::Models::NetworkInterface.mapper
-          network_client.deserialize(network_interface_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(network_interface_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.detach_pip_from_nic_response(network_client)
@@ -126,7 +126,7 @@ module ApiStub
             }
           }'
           network_interface_mapper = Azure::ARM::Network::Models::NetworkInterface.mapper
-          network_client.deserialize(network_interface_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(network_interface_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.detach_nsg_from_nic_response(network_client)
@@ -185,7 +185,7 @@ module ApiStub
             }
           }'
           network_interface_mapper = Azure::ARM::Network::Models::NetworkInterface.mapper
-          network_client.deserialize(network_interface_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(network_interface_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_network_interfaces_response(network_client)
@@ -252,7 +252,7 @@ module ApiStub
             } ]
           }'
           network_interface_list_mapper = Azure::ARM::Network::Models::NetworkInterfaceListResult.mapper
-          network_client.deserialize(network_interface_list_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(network_interface_list_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.delete_network_interface_response

--- a/test/api_stub/requests/network/network_security_group.rb
+++ b/test/api_stub/requests/network/network_security_group.rb
@@ -65,7 +65,7 @@ module ApiStub
              }
           }'
           result_mapper = Azure::ARM::Network::Models::NetworkSecurityGroup.mapper
-          network_client.deserialize(result_mapper, JSON.load(nsg), 'result.body')
+          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg), 'result.body')
         end
 
         def self.add_security_rules_response(network_client)
@@ -144,7 +144,7 @@ module ApiStub
              }
           }'
           result_mapper = Azure::ARM::Network::Models::NetworkSecurityGroup.mapper
-          network_client.deserialize(result_mapper, JSON.load(nsg), 'result.body')
+          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg), 'result.body')
         end
 
         def self.list_network_security_group_response(network_client)
@@ -217,7 +217,7 @@ module ApiStub
             ]
           }'
           result_mapper = Azure::ARM::Network::Models::NetworkInterfaceListResult.mapper
-          network_client.deserialize(result_mapper, JSON.load(nsg_list), 'result.body')
+          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg_list), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/network/network_security_rule.rb
+++ b/test/api_stub/requests/network/network_security_rule.rb
@@ -22,7 +22,7 @@ module ApiStub
               }
           }'
           nsr_mapper = Azure::ARM::Network::Models::SecurityRule.mapper
-          network_client.deserialize(nsr_mapper, JSON.load(nsr), 'result.body')
+          network_client.deserialize(nsr_mapper, Fog::JSON.decode(nsr), 'result.body')
         end
 
         def self.network_security_rule_paramteres_hash
@@ -64,7 +64,7 @@ module ApiStub
           ]
           }'
           nsr_mapper = Azure::ARM::Network::Models::SecurityRuleListResult.mapper
-          network_client.deserialize(nsr_mapper, JSON.load(nsr_list), 'result.body')
+          network_client.deserialize(nsr_mapper, Fog::JSON.decode(nsr_list), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/network/public_ip.rb
+++ b/test/api_stub/requests/network/public_ip.rb
@@ -28,7 +28,7 @@ module ApiStub
              }
           }'
           public_ip_mapper = Azure::ARM::Network::Models::PublicIPAddress.mapper
-          network_client.deserialize(public_ip_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(public_ip_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_public_ips_response(network_client)
@@ -59,7 +59,7 @@ module ApiStub
             } ]
           }'
           public_ip_mapper = Azure::ARM::Network::Models::PublicIPAddressListResult.mapper
-          network_client.deserialize(public_ip_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(public_ip_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.delete_public_ip_response

--- a/test/api_stub/requests/network/subnet.rb
+++ b/test/api_stub/requests/network/subnet.rb
@@ -28,7 +28,7 @@ module ApiStub
              }
           }'
           subnet_mapper = Azure::ARM::Network::Models::Subnet.mapper
-          network_client.deserialize(subnet_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(subnet_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_subnets_response(network_client)
@@ -59,7 +59,7 @@ module ApiStub
             } ]
           }'
           subnet_mapper = Azure::ARM::Network::Models::SubnetListResult.mapper
-          network_client.deserialize(subnet_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(subnet_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.delete_subnet_response

--- a/test/api_stub/requests/network/virtual_network.rb
+++ b/test/api_stub/requests/network/virtual_network.rb
@@ -54,7 +54,7 @@ module ApiStub
              }
           }'
           vnet_mapper = Azure::ARM::Network::Models::VirtualNetwork.mapper
-          network_client.deserialize(vnet_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(vnet_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_virtual_networks_response(network_client)
@@ -113,7 +113,7 @@ module ApiStub
             } ]
           }'
           vnet_mapper = Azure::ARM::Network::Models::VirtualNetworkListResult.mapper
-          network_client.deserialize(vnet_mapper, JSON.load(body), 'result.body')
+          network_client.deserialize(vnet_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.delete_virtual_network_response

--- a/test/api_stub/requests/network/virtual_network_gateway.rb
+++ b/test/api_stub/requests/network/virtual_network_gateway.rb
@@ -16,7 +16,7 @@ module ApiStub
             }
           }'
           gateway_mapper = Azure::ARM::Network::Models::VirtualNetworkGateway.mapper
-          network_client.deserialize(gateway_mapper, JSON.load(network_gateway), 'result.body')
+          network_client.deserialize(gateway_mapper, Fog::JSON.decode(network_gateway), 'result.body')
         end
 
         def self.list_virtual_network_gateway_response(network_client)
@@ -37,7 +37,7 @@ module ApiStub
             ]
           }'
           gateway_mapper = Azure::ARM::Network::Models::VirtualNetworkGatewayListResult.mapper
-          network_client.deserialize(gateway_mapper, JSON.load(network_gateway), 'result.body')
+          network_client.deserialize(gateway_mapper, Fog::JSON.decode(network_gateway), 'result.body')
         end
 
         def self.delete_virtual_network_gateway_response

--- a/test/api_stub/requests/network/virtual_network_gateway_connection.rb
+++ b/test/api_stub/requests/network/virtual_network_gateway_connection.rb
@@ -23,7 +23,7 @@ module ApiStub
             }
           }'
           connection_mapper = Azure::ARM::Network::Models::VirtualNetworkGatewayConnection.mapper
-          network_client.deserialize(connection_mapper, JSON.load(gateway_connection), 'result.body')
+          network_client.deserialize(connection_mapper, Fog::JSON.decode(gateway_connection), 'result.body')
         end
 
         def self.list_virtual_network_gateway_connection_response(network_client)
@@ -50,13 +50,13 @@ module ApiStub
             ]
           }'
           connection_mapper = Azure::ARM::Network::Models::VirtualNetworkGatewayConnectionListResult.mapper
-          network_client.deserialize(connection_mapper, JSON.load(gateway_connection), 'result.body')
+          network_client.deserialize(connection_mapper, Fog::JSON.decode(gateway_connection), 'result.body')
         end
 
         def self.get_connection_shared_key_response(network_client)
           shared_key = '{ "value": "hello" }'
           shared_key_mapper = Azure::ARM::Network::Models::ConnectionSharedKeyResult.mapper
-          network_client.deserialize(shared_key_mapper, JSON.load(shared_key), 'result.body')
+          network_client.deserialize(shared_key_mapper, Fog::JSON.decode(shared_key), 'result.body')
         end
 
         def self.delete_virtual_network_gateway_connection_response

--- a/test/api_stub/requests/resources/resource.rb
+++ b/test/api_stub/requests/resources/resource.rb
@@ -17,7 +17,7 @@ module ApiStub
             }
           }'
           result_mapper = Azure::ARM::Resources::Models::GenericResource.mapper
-          client.deserialize(result_mapper, JSON.load(body), 'result.body')
+          client.deserialize(result_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_tagged_resources_response(client)
@@ -37,7 +37,7 @@ module ApiStub
             "nextLink": "https://management.azure.com/subscriptions/########-####-####-####-############/resourcegroups?api-version=2015-01-01&$skiptoken=######"
           }'
           result_mapper = Azure::ARM::Resources::Models::ResourceListResult.mapper
-          client.deserialize(result_mapper, JSON.load(body), 'result.body')
+          client.deserialize(result_mapper, Fog::JSON.decode(body), 'result.body')
         end
       end
     end

--- a/test/api_stub/requests/resources/resource_group.rb
+++ b/test/api_stub/requests/resources/resource_group.rb
@@ -16,7 +16,7 @@ module ApiStub
             }
           }'
           result_mapper = Azure::ARM::Resources::Models::ResourceGroup.mapper
-          client.deserialize(result_mapper, JSON.load(body), 'result.body')
+          client.deserialize(result_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_resource_group_response(client)
@@ -35,7 +35,7 @@ module ApiStub
             "nextLink": "https://management.azure.com/subscriptions/########-####-####-####-############/resourcegroups?api-version=2015-01-01&$skiptoken=######"
           }'
           result_mapper = Azure::ARM::Resources::Models::ResourceGroupListResult.mapper
-          client.deserialize(result_mapper, JSON.load(body), 'result.body')
+          client.deserialize(result_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_resource_groups_for_zones

--- a/test/api_stub/requests/traffic_manager/traffic_manager_endpoint.rb
+++ b/test/api_stub/requests/traffic_manager/traffic_manager_endpoint.rb
@@ -18,7 +18,7 @@ module ApiStub
             }
           }'
           endpoint_mapper = Azure::ARM::TrafficManager::Models::Endpoint.mapper
-          traffic_manager_client.deserialize(endpoint_mapper, JSON.load(body), 'result.body')
+          traffic_manager_client.deserialize(endpoint_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.endpoint_hash

--- a/test/api_stub/requests/traffic_manager/traffic_manager_profile.rb
+++ b/test/api_stub/requests/traffic_manager/traffic_manager_profile.rb
@@ -66,7 +66,7 @@ module ApiStub
             }
           }'
           profile_mapper = Azure::ARM::TrafficManager::Models::Profile.mapper
-          traffic_manager_client.deserialize(profile_mapper, JSON.load(body), 'result.body')
+          traffic_manager_client.deserialize(profile_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.list_traffic_manager_profiles_response(traffic_manager_client)
@@ -134,7 +134,7 @@ module ApiStub
             }]
           }'
           profile_mapper = Azure::ARM::TrafficManager::Models::ProfileListResult.mapper
-          traffic_manager_client.deserialize(profile_mapper, JSON.load(body), 'result.body')
+          traffic_manager_client.deserialize(profile_mapper, Fog::JSON.decode(body), 'result.body')
         end
 
         def self.profile_hash


### PR DESCRIPTION
Updated code to use entire namespace of model instead of only the model name. This will prevent any conflicts with existing providers in fog.