### PR TITLE
Bugfix/change check exist file names

### DIFF
--- a/lib/fog/azurerm/application_gateway.rb
+++ b/lib/fog/azurerm/application_gateway.rb
@@ -13,7 +13,7 @@ module Fog
       request :delete_application_gateway
       request :list_application_gateways
       request :get_application_gateway
-      request :check_ag_exists?
+      request :check_ag_exists
       request :update_subnet_id_in_gateway_ip_configuration
       request :update_sku_attributes
       request :start_application_gateway

--- a/lib/fog/azurerm/compute.rb
+++ b/lib/fog/azurerm/compute.rb
@@ -13,7 +13,7 @@ module Fog
       request :delete_availability_set
       request :list_availability_sets
       request :get_availability_set
-      request :check_availability_set_exists?
+      request :check_availability_set_exists
       request :create_virtual_machine
       request :delete_virtual_machine
       request :get_virtual_machine
@@ -26,13 +26,13 @@ module Fog
       request :restart_virtual_machine
       request :start_virtual_machine
       request :check_vm_status
-      request :check_vm_exists?
+      request :check_vm_exists
       request :attach_data_disk_to_vm
       request :detach_data_disk_from_vm
       request :create_or_update_vm_extension
       request :delete_vm_extension
       request :get_vm_extension
-      request :check_vm_extension_exists?
+      request :check_vm_extension_exists
 
       model_path 'fog/azurerm/models/compute'
       model :availability_set

--- a/lib/fog/azurerm/dns.rb
+++ b/lib/fog/azurerm/dns.rb
@@ -11,7 +11,7 @@ module Fog
       request_path 'fog/azurerm/requests/dns'
       request :create_or_update_zone
       request :delete_zone
-      request :check_zone_exists?
+      request :check_zone_exists
       request :list_zones
       request :get_zone
       request :create_or_update_record_set
@@ -19,7 +19,7 @@ module Fog
       request :list_record_sets
       request :get_records_from_record_set
       request :get_record_set
-      request :check_record_set_exists?
+      request :check_record_set_exists
 
       model_path 'fog/azurerm/models/dns'
       model :zone

--- a/lib/fog/azurerm/docs/application_gateway.md
+++ b/lib/fog/azurerm/docs/application_gateway.md
@@ -26,7 +26,7 @@ Next, create a connection to the Application Gateway Service:
 ## Check Application Gateway Existence
 
 ```ruby
-azure_application_gateway_service.gateways.check_application_gateway_exists?(<Resource Group name>, <Gateway Name>)
+azure_application_gateway_service.gateways.check_application_gateway_exists(<Resource Group name>, <Gateway Name>)
 ```
 
 ## Create Application Gateway

--- a/lib/fog/azurerm/docs/compute.md
+++ b/lib/fog/azurerm/docs/compute.md
@@ -28,7 +28,7 @@ Next, create a connection to the Compute Service:
 ## Check Server Existence
 
 ```ruby
-azure_compute_service.servers.check_vm_exists?(<Resource Group name>, <VM Name>)
+azure_compute_service.servers.check_vm_exists(<Resource Group name>, <VM Name>)
 ```
 
 ## Create Server
@@ -143,7 +143,7 @@ Get a server object from the get method(described above) and then destroy that s
 ## Check Availability Set Existence
 
 ```ruby
-azure_compute_service.availability_sets.check_availability_set_exists?(<Resource Group name>, <Availability Set name>)
+azure_compute_service.availability_sets.check_availability_set_exists(<Resource Group name>, <Availability Set name>)
 ```
 
 ## Create Availability Set
@@ -191,7 +191,7 @@ Get an availability set object from the get method and then destroy that availab
 ## Check Virtual Machine Extension Existence
 
 ```ruby
-azure_compute_service.virtual_machine_extensions.check_vm_extension_exists?(<Resource Group name>, <Virtual Machine Name>, <Extension Name>)
+azure_compute_service.virtual_machine_extensions.check_vm_extension_exists(<Resource Group name>, <Virtual Machine Name>, <Extension Name>)
 ```
 
 ## Create Virtual Machine Extension

--- a/lib/fog/azurerm/docs/dns.md
+++ b/lib/fog/azurerm/docs/dns.md
@@ -27,7 +27,7 @@ Next, create a connection to the DNS Service:
 ## Check Zone Existence
 
 ```ruby
-azure_dns_service.zones.check_zone_exists?(<Resource Group name>, <Zone name>)
+azure_dns_service.zones.check_zone_exists(<Resource Group name>, <Zone name>)
 ```
 
 ## Create Zone
@@ -71,7 +71,7 @@ Get Zone object from the get method(described above) and then destroy that Zone.
 ## Check Record Set Existence
 
 ```ruby
-azure_dns_service.record_sets.check_record_set_exists?(<Resource Group name>, <Record Set name>, <Zone name>, <Record Type(A/CNAME)>)
+azure_dns_service.record_sets.check_record_set_exists(<Resource Group name>, <Record Set name>, <Zone name>, <Record Type(A/CNAME)>)
 ```
 
 ## Create Record Set

--- a/lib/fog/azurerm/docs/key_vault.md
+++ b/lib/fog/azurerm/docs/key_vault.md
@@ -25,7 +25,7 @@ Next, create a connection to the Key Vault Service:
 ## Check Vault Existence
 
 ```ruby
- azure_key_vault_service.vaults.check_vault_exists?(<Resource Group name>, <Vault Name>)
+ azure_key_vault_service.vaults.check_vault_exists(<Resource Group name>, <Vault Name>)
 ```
 
 ## Create Vault

--- a/lib/fog/azurerm/docs/network.md
+++ b/lib/fog/azurerm/docs/network.md
@@ -26,7 +26,7 @@ Next, create a connection to the Network Service:
 ## Check Virtual Network Existence
 
 ```ruby
- azure_network_service.virtual_networks.check_virtual_network_exists?(<Resource Group name>, <Virtual Network Name>)
+ azure_network_service.virtual_networks.check_virtual_network_exists(<Resource Group name>, <Virtual Network Name>)
 ```
 
 ## Create Virtual Network
@@ -141,7 +141,7 @@ Get virtual network object from the get method and then destroy that virtual net
 ## Check Subnet Existence
 
 ```ruby
- azure_network_service.subnets.check_subnet_exists?(<Resource Group name>, <Virtual Network Name>, <Subnet Name>)
+ azure_network_service.subnets.check_subnet_exists(<Resource Group name>, <Virtual Network Name>, <Subnet Name>)
 ```
 
 ## Create Subnet
@@ -238,7 +238,7 @@ Get a subnet object from the get method and then destroy that subnet.
 ## Check Network Interface Card Existence
 
 ```ruby
- azure_network_service.network_interfaces.check_network_interface_exists?(<Resource Group name>, <Network Interface name>)
+ azure_network_service.network_interfaces.check_network_interface_exists(<Resource Group name>, <Network Interface name>)
 ```
 
 ## Create Network Interface Card
@@ -321,7 +321,7 @@ Get a network interface object from the get method and then destroy that network
 ## Check Public IP Existence
 
 ```ruby
- azure_network_service.public_ips.check_public_ip_exists?(<Resource Group name>, <Public IP name>>)
+ azure_network_service.public_ips.check_public_ip_exists(<Resource Group name>, <Public IP name>>)
 ```
 
 ## Create Public IP
@@ -390,7 +390,7 @@ Get a Public IP object from the get method and then destroy that public IP.
 ## Check Network Security Group Existence
 
 ```ruby
- azure_network_service.network_security_groups.check_net_sec_group_exists?(<Resource Group name>, <Network Security Group name>)
+ azure_network_service.network_security_groups.check_net_sec_group_exists(<Resource Group name>, <Network Security Group name>)
 ```
 
 ## Create Network Security Group
@@ -501,7 +501,7 @@ Get a network security group object from the get method and then destroy that ne
 ## Check Network Security Rule Existence
 
 ```ruby
- azure_network_service.network_security_rules.check_net_sec_rule_exists?(<Resource Group name>, <Network Security Group name>, <Security Rule name>)
+ azure_network_service.network_security_rules.check_net_sec_rule_exists(<Resource Group name>, <Network Security Group name>, <Security Rule name>)
 ```
 
 ## Create Network Security Rule
@@ -558,7 +558,7 @@ Get a network security rule object from the get method and then destroy that net
 ## Check External Load Balancer Existence
 
 ```ruby
- azure_network_service.load_balancers.check_load_balancer_exists?(<Resource Group name>, <Load Balancer name>)
+ azure_network_service.load_balancers.check_load_balancer_exists(<Resource Group name>, <Load Balancer name>)
 ```
 
 ## Create External Load Balancer
@@ -718,7 +718,7 @@ Get a load balancer object from the get method and then destroy that load balanc
 ## Check Virtual Network Gateway Existence
 
 ```ruby
- azure_network_service.virtual_network_gateways.check_vnet_gateway_exists?(<Resource Group name>, <Virtual Network Gateway Name>)
+ azure_network_service.virtual_network_gateways.check_vnet_gateway_exists(<Resource Group name>, <Virtual Network Gateway Name>)
 ```
 
 ## Create Virtual Network Gateway
@@ -805,7 +805,7 @@ Get a virtual network gateway object from the get method and then destroy that v
 ## Check Local Network Gateway Existence
 
 ```ruby
- azure_network_service.local_network_gateways.check_local_net_gateway_exists?(<Resource Group name>, <Local Network Gateway Name>)
+ azure_network_service.local_network_gateways.check_local_net_gateway_exists(<Resource Group name>, <Local Network Gateway Name>)
 ```
 
 ## Create Local Network Gateway
@@ -869,7 +869,7 @@ The Circuit represents the entity created by customer to register with an expres
 ## Check Express Route Circuit Existence
 
 ```ruby
- azure_network_service.express_route_circuits.check_express_route_circuit_exists?(<Resource Group name>, <Circuit Name>)
+ azure_network_service.express_route_circuits.check_express_route_circuit_exists(<Resource Group name>, <Circuit Name>)
 ```
 
 ## Create an Express Route Circuit
@@ -938,7 +938,7 @@ Authorization is part of Express Route circuit.
 ## Check Express Route Circuit Authorization Existence
 
 ```ruby
- azure_network_service.express_route_circuit_authorizations.check_express_route_cir_auth_exists?(<Resource Group name>, <Circuit Name>, <Authorization-Name>)
+ azure_network_service.express_route_circuit_authorizations.check_express_route_cir_auth_exists(<Resource Group name>, <Circuit Name>, <Authorization-Name>)
 ```
 
 ## Create an Express Route Circuit Authorization
@@ -1049,7 +1049,7 @@ List all express route service providers
 ## Check Virtual Network Gateway Connection Existence
 
 ```ruby
- azure_network_service.virtual_network_gateway_connections.check_vnet_gateway_connection_exists?(<Resource Group name>, <Virtual Network Gateway Connection Name>)
+ azure_network_service.virtual_network_gateway_connections.check_vnet_gateway_connection_exists(<Resource Group name>, <Virtual Network Gateway Connection Name>)
 ```
 
 ## Create Virtual Network Gateway Connection

--- a/lib/fog/azurerm/docs/resources.md
+++ b/lib/fog/azurerm/docs/resources.md
@@ -27,7 +27,7 @@ Next, create a connection to the Resources Service:
 ## Check Resource Group Existence
 
 ```ruby
- azure_resources_service.resource_groups.check_resource_group_exists?(<Resource Group name>)
+ azure_resources_service.resource_groups.check_resource_group_exists(<Resource Group name>)
 ```
 
 ## Create Resource Group
@@ -121,13 +121,13 @@ Remove tag from a resource as following:
 ## Check Resource Existence
 
 ```ruby
- azure_resources_service.azure_resources.check_azure_resource_exists?(<Resource-ID>, <API-Version>)
+ azure_resources_service.azure_resources.check_azure_resource_exists(<Resource-ID>, <API-Version>)
 ```
 
 ## Check Deployment Existence
 
 ```ruby
- azure_resources_service.deployments.check_deployment_exists?(<Resource Group Name>, <Deployment name>)
+ azure_resources_service.deployments.check_deployment_exists(<Resource Group Name>, <Deployment name>)
 ```
 
 ## Create Deployment

--- a/lib/fog/azurerm/docs/storage.md
+++ b/lib/fog/azurerm/docs/storage.md
@@ -62,7 +62,7 @@ azure_storage_service.storage_accounts.check_name_availability('<Storage Account
 ## Check Storage Account Existence
 
 ```ruby
-azure_storage_service.storage_accounts.check_storage_account_exists?(<Resource Group name>, <StorageAccountName>)
+azure_storage_service.storage_accounts.check_storage_account_exists(<Resource Group name>, <StorageAccountName>)
 ```
 
 ## Create Storage Account
@@ -170,7 +170,7 @@ azure_storage_service.delete_disk('<Data Disk Name>', options = {})
 ## Check Storage Container Existence
 
 ```ruby
-azure_storage_service.directories.check_container_exists?(<container name>)
+azure_storage_service.directories.check_container_exists(<container name>)
 ```
 
 ## Create a storage container

--- a/lib/fog/azurerm/docs/traffic_manager.md
+++ b/lib/fog/azurerm/docs/traffic_manager.md
@@ -26,7 +26,7 @@ Next, create a connection to the Traffic Manager Service:
 ## Check Traffic Manager Profile Existence
 
 ```ruby
-azure_traffic_manager_service.traffic_manager_profiles.check_traffic_manager_profile_exists?(<Resource Group Name>, <Profile Name>)
+azure_traffic_manager_service.traffic_manager_profiles.check_traffic_manager_profile_exists(<Resource Group Name>, <Profile Name>)
 ```
 
 ## Create Traffic Manager Profile
@@ -93,7 +93,7 @@ Get a Traffic Manager Profile object from the get method and then destroy that T
 ## Check Traffic Manager Endpoint Existence
 
 ```ruby
- azure_network_service.traffic_manager_end_points.check_traffic_manager_endpoint_exists?(
+ azure_network_service.traffic_manager_end_points.check_traffic_manager_endpoint_exists(
    <Resource Group Name>,
    <Profile Name>,
    <Endpoint Name>,

--- a/lib/fog/azurerm/key_vault.rb
+++ b/lib/fog/azurerm/key_vault.rb
@@ -12,7 +12,7 @@ module Fog
       request :list_vaults
       request :create_or_update_vault
       request :delete_vault
-      request :check_vault_exists?
+      request :check_vault_exists
 
       model_path 'fog/azurerm/models/key_vault'
       model :vault

--- a/lib/fog/azurerm/models/application_gateway/gateways.rb
+++ b/lib/fog/azurerm/models/application_gateway/gateways.rb
@@ -21,8 +21,8 @@ module Fog
           application_gateway.merge_attributes(Fog::ApplicationGateway::AzureRM::Gateway.parse(gateway))
         end
 
-        def check_application_gateway_exists?(resource_group_name, application_gateway_name)
-          service.check_ag_exists?(resource_group_name, application_gateway_name)
+        def check_application_gateway_exists(resource_group_name, application_gateway_name)
+          service.check_ag_exists(resource_group_name, application_gateway_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/availability_sets.rb
+++ b/lib/fog/azurerm/models/compute/availability_sets.rb
@@ -26,8 +26,8 @@ module Fog
           availability_set_fog.merge_attributes(Fog::Compute::AzureRM::AvailabilitySet.parse(availability_set))
         end
 
-        def check_availability_set_exists?(resource_group, name)
-          service.check_availability_set_exists?(resource_group, name)
+        def check_availability_set_exists(resource_group, name)
+          service.check_availability_set_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/servers.rb
+++ b/lib/fog/azurerm/models/compute/servers.rb
@@ -22,8 +22,8 @@ module Fog
           virtual_machine_fog.merge_attributes(Fog::Compute::AzureRM::Server.parse(virtual_machine))
         end
 
-        def check_vm_exists?(resource_group, name)
-          service.check_vm_exists?(resource_group, name)
+        def check_vm_exists(resource_group, name)
+          service.check_vm_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
+++ b/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
@@ -22,8 +22,8 @@ module Fog
           vm_extension_fog.merge_attributes(Fog::Compute::AzureRM::VirtualMachineExtension.parse(vm_extension))
         end
 
-        def check_vm_extension_exists?(resource_group_name, virtual_machine_name, vm_extension_name)
-          service.check_vm_extension_exists?(resource_group_name, virtual_machine_name, vm_extension_name)
+        def check_vm_extension_exists(resource_group_name, virtual_machine_name, vm_extension_name)
+          service.check_vm_extension_exists(resource_group_name, virtual_machine_name, vm_extension_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/dns/record_sets.rb
+++ b/lib/fog/azurerm/models/dns/record_sets.rb
@@ -25,8 +25,8 @@ module Fog
           record_set_fog.merge_attributes(Fog::DNS::AzureRM::RecordSet.parse(record_set))
         end
 
-        def check_record_set_exists?(resource_group, name, zone_name, record_type)
-          service.check_record_set_exists?(resource_group, name, zone_name, record_type)
+        def check_record_set_exists(resource_group, name, zone_name, record_type)
+          service.check_record_set_exists(resource_group, name, zone_name, record_type)
         end
       end
     end

--- a/lib/fog/azurerm/models/dns/zones.rb
+++ b/lib/fog/azurerm/models/dns/zones.rb
@@ -20,8 +20,8 @@ module Fog
           zone_fog.merge_attributes(Fog::DNS::AzureRM::Zone.parse(zone))
         end
 
-        def check_zone_exists?(resource_group, name)
-          service.check_zone_exists?(resource_group, name)
+        def check_zone_exists(resource_group, name)
+          service.check_zone_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/key_vault/vaults.rb
+++ b/lib/fog/azurerm/models/key_vault/vaults.rb
@@ -18,8 +18,8 @@ module Fog
           vault_obj.merge_attributes(Fog::KeyVault::AzureRM::Vault.parse(vault))
         end
 
-        def check_vault_exists?(resource_group, vault_name)
-          service.check_vault_exists?(resource_group, vault_name)
+        def check_vault_exists(resource_group, vault_name)
+          service.check_vault_exists(resource_group, vault_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/express_route_circuit_authorizations.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuit_authorizations.rb
@@ -19,8 +19,8 @@ module Fog
           express_route_circuit_authorization.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuitAuthorization.parse(circuit_authorization))
         end
 
-        def check_express_route_cir_auth_exists?(resource_group_name, circuit_name, authorization_name)
-          service.check_express_route_cir_auth_exists?(resource_group_name, circuit_name, authorization_name)
+        def check_express_route_cir_auth_exists(resource_group_name, circuit_name, authorization_name)
+          service.check_express_route_cir_auth_exists(resource_group_name, circuit_name, authorization_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/express_route_circuits.rb
+++ b/lib/fog/azurerm/models/network/express_route_circuits.rb
@@ -21,8 +21,8 @@ module Fog
           express_route_circuit.merge_attributes(Fog::Network::AzureRM::ExpressRouteCircuit.parse(circuit))
         end
 
-        def check_express_route_circuit_exists?(resource_group_name, name)
-          service.check_express_route_circuit_exists?(resource_group_name, name)
+        def check_express_route_circuit_exists(resource_group_name, name)
+          service.check_express_route_circuit_exists(resource_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/load_balancers.rb
+++ b/lib/fog/azurerm/models/network/load_balancers.rb
@@ -27,8 +27,8 @@ module Fog
           load_balancer_fog.merge_attributes(Fog::Network::AzureRM::LoadBalancer.parse(load_balancer))
         end
 
-        def check_load_balancer_exists?(resource_group_name, load_balancer_name)
-          service.check_load_balancer_exists?(resource_group_name, load_balancer_name)
+        def check_load_balancer_exists(resource_group_name, load_balancer_name)
+          service.check_load_balancer_exists(resource_group_name, load_balancer_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/local_network_gateways.rb
+++ b/lib/fog/azurerm/models/network/local_network_gateways.rb
@@ -18,8 +18,8 @@ module Fog
           local_network_gateway_fog.merge_attributes(Fog::Network::AzureRM::LocalNetworkGateway.parse(local_network_gateway))
         end
 
-        def check_local_net_gateway_exists?(resource_group_name, name)
-          service.check_local_net_gateway_exists?(resource_group_name, name)
+        def check_local_net_gateway_exists(resource_group_name, name)
+          service.check_local_net_gateway_exists(resource_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_interfaces.rb
+++ b/lib/fog/azurerm/models/network/network_interfaces.rb
@@ -21,8 +21,8 @@ module Fog
           network_interface_card_fog.merge_attributes(Fog::Network::AzureRM::NetworkInterface.parse(network_interface_card))
         end
 
-        def check_network_interface_exists?(resource_group_name, name)
-          service.check_network_interface_exists?(resource_group_name, name)
+        def check_network_interface_exists(resource_group_name, name)
+          service.check_network_interface_exists(resource_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_security_groups.rb
+++ b/lib/fog/azurerm/models/network/network_security_groups.rb
@@ -21,8 +21,8 @@ module Fog
           network_security_group_fog.merge_attributes(Fog::Network::AzureRM::NetworkSecurityGroup.parse(network_security_group))
         end
 
-        def check_net_sec_group_exists?(resource_group, name)
-          service.check_net_sec_group_exists?(resource_group, name)
+        def check_net_sec_group_exists(resource_group, name)
+          service.check_net_sec_group_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/network_security_rules.rb
+++ b/lib/fog/azurerm/models/network/network_security_rules.rb
@@ -22,8 +22,8 @@ module Fog
           network_security_rule_fog.merge_attributes(Fog::Network::AzureRM::NetworkSecurityRule.parse(network_security_rule))
         end
 
-        def check_net_sec_rule_exists?(resource_group, network_security_group_name, name)
-          service.check_net_sec_rule_exists?(resource_group, network_security_group_name, name)
+        def check_net_sec_rule_exists(resource_group, network_security_group_name, name)
+          service.check_net_sec_rule_exists(resource_group, network_security_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/public_ips.rb
+++ b/lib/fog/azurerm/models/network/public_ips.rb
@@ -21,8 +21,8 @@ module Fog
           public_ip_fog.merge_attributes(Fog::Network::AzureRM::PublicIp.parse(public_ip))
         end
 
-        def check_public_ip_exists?(resource_group, name)
-          service.check_public_ip_exists?(resource_group, name)
+        def check_public_ip_exists(resource_group, name)
+          service.check_public_ip_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/subnets.rb
+++ b/lib/fog/azurerm/models/network/subnets.rb
@@ -22,8 +22,8 @@ module Fog
           subnet_fog.merge_attributes(Fog::Network::AzureRM::Subnet.parse(subnet))
         end
 
-        def check_subnet_exists?(resource_group, virtual_network_name, subnet_name)
-          service.check_subnet_exists?(resource_group, virtual_network_name, subnet_name)
+        def check_subnet_exists(resource_group, virtual_network_name, subnet_name)
+          service.check_subnet_exists(resource_group, virtual_network_name, subnet_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_network_gateway_connections.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateway_connections.rb
@@ -18,8 +18,8 @@ module Fog
           gateway_connection.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGatewayConnection.parse(connection))
         end
 
-        def check_vnet_gateway_connection_exists?(resource_group_name, name)
-          service.check_vnet_gateway_connection_exists?(resource_group_name, name)
+        def check_vnet_gateway_connection_exists(resource_group_name, name)
+          service.check_vnet_gateway_connection_exists(resource_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_network_gateways.rb
+++ b/lib/fog/azurerm/models/network/virtual_network_gateways.rb
@@ -21,8 +21,8 @@ module Fog
           virtual_network_gateway.merge_attributes(Fog::Network::AzureRM::VirtualNetworkGateway.parse(network_gateway))
         end
 
-        def check_vnet_gateway_exists?(resource_group_name, name)
-          service.check_vnet_gateway_exists?(resource_group_name, name)
+        def check_vnet_gateway_exists(resource_group_name, name)
+          service.check_vnet_gateway_exists(resource_group_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/network/virtual_networks.rb
+++ b/lib/fog/azurerm/models/network/virtual_networks.rb
@@ -27,8 +27,8 @@ module Fog
           virtual_network_fog.merge_attributes(Fog::Network::AzureRM::VirtualNetwork.parse(virtual_network))
         end
 
-        def check_virtual_network_exists?(resource_group, name)
-          service.check_virtual_network_exists?(resource_group, name)
+        def check_virtual_network_exists(resource_group, name)
+          service.check_virtual_network_exists(resource_group, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/resources/azure_resources.rb
+++ b/lib/fog/azurerm/models/resources/azure_resources.rb
@@ -23,8 +23,8 @@ module Fog
           all.find { |f| f.id == resource_id }
         end
 
-        def check_azure_resource_exists?(resource_id, api_version)
-          service.check_azure_resource_exists?(resource_id, api_version)
+        def check_azure_resource_exists(resource_id, api_version)
+          service.check_azure_resource_exists(resource_id, api_version)
         end
       end
     end

--- a/lib/fog/azurerm/models/resources/deployments.rb
+++ b/lib/fog/azurerm/models/resources/deployments.rb
@@ -21,8 +21,8 @@ module Fog
           deployment_fog.merge_attributes(Fog::Resources::AzureRM::Deployment.parse(deployment))
         end
 
-        def check_deployment_exists?(resource_group_name, deployment_name)
-          service.check_deployment_exists?(resource_group_name, deployment_name)
+        def check_deployment_exists(resource_group_name, deployment_name)
+          service.check_deployment_exists(resource_group_name, deployment_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/resources/resource_groups.rb
+++ b/lib/fog/azurerm/models/resources/resource_groups.rb
@@ -20,8 +20,8 @@ module Fog
           resource_group_fog.merge_attributes(Fog::Resources::AzureRM::ResourceGroup.parse(resource_group))
         end
 
-        def check_resource_group_exists?(resource_group_name)
-          service.check_resource_group_exists?(resource_group_name)
+        def check_resource_group_exists(resource_group_name)
+          service.check_resource_group_exists(resource_group_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/firewall_rules.rb
+++ b/lib/fog/azurerm/models/sql/firewall_rules.rb
@@ -23,8 +23,8 @@ module Fog
           firewall_rule_fog.merge_attributes(Fog::Sql::AzureRM::FirewallRule.parse(firewall_rule))
         end
 
-        def check_firewall_rule_exists?(resource_group, server_name, rule_name)
-          service.check_firewall_rule_exists?(resource_group, server_name, rule_name)
+        def check_firewall_rule_exists(resource_group, server_name, rule_name)
+          service.check_firewall_rule_exists(resource_group, server_name, rule_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/sql_databases.rb
+++ b/lib/fog/azurerm/models/sql/sql_databases.rb
@@ -23,8 +23,8 @@ module Fog
           database_fog.merge_attributes(Fog::Sql::AzureRM::SqlDatabase.parse(database))
         end
 
-        def check_database_exists?(resource_group, server_name, name)
-          service.check_database_exists?(resource_group, server_name, name)
+        def check_database_exists(resource_group, server_name, name)
+          service.check_database_exists(resource_group, server_name, name)
         end
       end
     end

--- a/lib/fog/azurerm/models/sql/sql_servers.rb
+++ b/lib/fog/azurerm/models/sql/sql_servers.rb
@@ -22,8 +22,8 @@ module Fog
           server_fog.merge_attributes(Fog::Sql::AzureRM::SqlServer.parse(server))
         end
 
-        def check_sql_server_exists?(resource_group, server_name)
-          service.check_sql_server_exists?(resource_group, server_name)
+        def check_sql_server_exists(resource_group, server_name)
+          service.check_sql_server_exists(resource_group, server_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/storage/directories.rb
+++ b/lib/fog/azurerm/models/storage/directories.rb
@@ -61,8 +61,8 @@ module Fog
           raise error
         end
 
-        def check_container_exists?(name)
-          service.check_container_exists?(name)
+        def check_container_exists(name)
+          service.check_container_exists(name)
         end
       end
     end

--- a/lib/fog/azurerm/models/storage/storage_accounts.rb
+++ b/lib/fog/azurerm/models/storage/storage_accounts.rb
@@ -34,8 +34,8 @@ module Fog
           service.check_storage_account_name_availability(params)
         end
 
-        def check_storage_account_exists?(resource_group_name, storage_account_name)
-          service.check_storage_account_exists?(resource_group_name, storage_account_name)
+        def check_storage_account_exists(resource_group_name, storage_account_name)
+          service.check_storage_account_exists(resource_group_name, storage_account_name)
         end
       end
     end

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_points.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_end_points.rb
@@ -21,8 +21,8 @@ module Fog
           endpoint_fog.merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerEndPoint.parse(endpoint))
         end
 
-        def check_traffic_manager_endpoint_exists?(resource_group, traffic_manager_profile_name, end_point_name, type)
-          service.check_traffic_manager_endpoint_exists?(resource_group, traffic_manager_profile_name, end_point_name, type)
+        def check_traffic_manager_endpoint_exists(resource_group, traffic_manager_profile_name, end_point_name, type)
+          service.check_traffic_manager_endpoint_exists(resource_group, traffic_manager_profile_name, end_point_name, type)
         end
       end
     end

--- a/lib/fog/azurerm/models/traffic_manager/traffic_manager_profiles.rb
+++ b/lib/fog/azurerm/models/traffic_manager/traffic_manager_profiles.rb
@@ -18,8 +18,8 @@ module Fog
           profile_fog.merge_attributes(Fog::TrafficManager::AzureRM::TrafficManagerProfile.parse(profile))
         end
 
-        def check_traffic_manager_profile_exists?(resource_group, traffic_manager_profile_name)
-          service.check_traffic_manager_profile_exists?(resource_group, traffic_manager_profile_name)
+        def check_traffic_manager_profile_exists(resource_group, traffic_manager_profile_name)
+          service.check_traffic_manager_profile_exists(resource_group, traffic_manager_profile_name)
         end
       end
     end

--- a/lib/fog/azurerm/network.rb
+++ b/lib/fog/azurerm/network.rb
@@ -20,12 +20,12 @@ module Fog
       request :delete_virtual_network
       request :list_virtual_networks
       request :list_virtual_networks_in_subscription
-      request :check_virtual_network_exists?
+      request :check_virtual_network_exists
       request :create_or_update_public_ip
       request :delete_public_ip
       request :get_public_ip
       request :list_public_ips
-      request :check_public_ip_exists?
+      request :check_public_ip_exists
       request :create_subnet
       request :attach_network_security_group_to_subnet
       request :detach_network_security_group_from_subnet
@@ -35,37 +35,37 @@ module Fog
       request :get_subnet
       request :get_available_ipaddresses_count
       request :delete_subnet
-      request :check_subnet_exists?
+      request :check_subnet_exists
       request :create_or_update_network_interface
       request :delete_network_interface
       request :list_network_interfaces
       request :get_network_interface
-      request :check_network_interface_exists?
+      request :check_network_interface_exists
       request :attach_resource_to_nic
       request :detach_resource_from_nic
       request :create_load_balancer
       request :delete_load_balancer
       request :list_load_balancers
       request :get_load_balancer
-      request :check_load_balancer_exists?
+      request :check_load_balancer_exists
       request :list_load_balancers_in_subscription
       request :create_or_update_network_security_group
       request :delete_network_security_group
       request :list_network_security_groups
       request :get_network_security_group
-      request :check_net_sec_group_exists?
+      request :check_net_sec_group_exists
       request :add_security_rules
       request :remove_security_rule
       request :delete_virtual_network_gateway
       request :create_or_update_virtual_network_gateway
       request :list_virtual_network_gateways
       request :get_virtual_network_gateway
-      request :check_vnet_gateway_exists?
+      request :check_vnet_gateway_exists
       request :create_or_update_express_route_circuit
       request :delete_express_route_circuit
       request :get_express_route_circuit
       request :list_express_route_circuits
-      request :check_express_route_circuit_exists?
+      request :check_express_route_circuit_exists
       request :create_or_update_express_route_circuit_peering
       request :delete_express_route_circuit_peering
       request :get_express_route_circuit_peering
@@ -74,18 +74,18 @@ module Fog
       request :delete_express_route_circuit_authorization
       request :get_express_route_circuit_authorization
       request :list_express_route_circuit_authorizations
-      request :check_express_route_cir_auth_exists?
+      request :check_express_route_cir_auth_exists
       request :list_express_route_service_providers
       request :create_or_update_local_network_gateway
       request :delete_local_network_gateway
       request :get_local_network_gateway
       request :list_local_network_gateways
-      request :check_local_net_gateway_exists?
+      request :check_local_net_gateway_exists
       request :create_or_update_virtual_network_gateway_connection
       request :delete_virtual_network_gateway_connection
       request :get_virtual_network_gateway_connection
       request :list_virtual_network_gateway_connections
-      request :check_vnet_gateway_connection_exists?
+      request :check_vnet_gateway_connection_exists
       request :get_connection_shared_key
       request :reset_connection_shared_key
       request :set_connection_shared_key
@@ -93,7 +93,7 @@ module Fog
       request :delete_network_security_rule
       request :get_network_security_rule
       request :list_network_security_rules
-      request :check_net_sec_rule_exists?
+      request :check_net_sec_rule_exists
 
       model_path 'fog/azurerm/models/network'
       model :virtual_network

--- a/lib/fog/azurerm/requests/application_gateway/check_ag_exists.rb
+++ b/lib/fog/azurerm/requests/application_gateway/check_ag_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module KeyVault
+  module ApplicationGateway
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_vault_exists?(resource_group, vault_name)
-          msg = "Checking Vault #{vault_name}"
+        def check_ag_exists(resource_group_name, application_gateway_name)
+          msg = "Checking Application Gateway: #{application_gateway_name}"
           Fog::Logger.debug msg
           begin
-            @key_vault_client.vaults.get(resource_group, vault_name)
-            Fog::Logger.debug "Vault #{vault_name} exists."
+            @network_client.application_gateways.get(resource_group_name, application_gateway_name)
+            Fog::Logger.debug "Application Gateway #{application_gateway_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Vault #{vault_name} doesn't exist."
+              Fog::Logger.debug "Application Gateway #{application_gateway_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_vault_exists?(*)
+        def check_ag_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/compute/check_availability_set_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_availability_set_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module DNS
+  module Compute
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_record_set_exists?(resource_group, name, zone_name, record_type)
-          msg = "Checking Record set #{name}"
+        def check_availability_set_exists(resource_group, name)
+          msg = "Checking Availability set: #{name}"
           Fog::Logger.debug msg
           begin
-            @dns_client.record_sets.get(resource_group, zone_name, name, record_type)
-            Fog::Logger.debug "Record set #{name} exists."
+            @compute_mgmt_client.availability_sets.get(resource_group, name)
+            Fog::Logger.debug "Availability set #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['code'] == 'NotFound'
-              Fog::Logger.debug "Record set #{name} doesn't exist."
+            if e.body['error']['code'] == 'ResourceNotFound'
+              Fog::Logger.debug "Availability set #{name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_record_set_exists?(_resource_group, _name)
+        def check_availability_set_exists(_resource_group, _name)
           true
         end
       end

--- a/lib/fog/azurerm/requests/compute/check_vm_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_vm_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module Network
+  module Compute
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_net_sec_rule_exists?(resource_group_name, network_security_group_name, security_rule_name)
-          msg = "Checking Network Security Rule #{security_rule_name}"
+        def check_vm_exists(resource_group, name)
+          msg = "Checking Virtual Machine #{name}"
           Fog::Logger.debug msg
           begin
-            @network_client.security_rules.get(resource_group_name, network_security_group_name, security_rule_name)
-            Fog::Logger.debug "Network Security Rule #{security_rule_name} exists."
+            @compute_mgmt_client.virtual_machines.get(resource_group, name, 'instanceView')
+            Fog::Logger.debug "Virtual machine #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Network Security Rule #{security_rule_name} doesn't exist."
+              Fog::Logger.debug "Virtual machine #{name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_net_sec_rule_exists?(*)
+        def check_vm_exists(_resource_group, _name)
           true
         end
       end

--- a/lib/fog/azurerm/requests/compute/check_vm_extension_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_vm_extension_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_availability_set_exists?(resource_group, name)
-          msg = "Checking Availability set: #{name}"
+        def check_vm_extension_exists(resource_group_name, virtual_machine_name, vm_extension_name)
+          msg = "Checking Virtual Machine Extension #{vm_extension_name}"
           Fog::Logger.debug msg
           begin
-            @compute_mgmt_client.availability_sets.get(resource_group, name)
-            Fog::Logger.debug "Availability set #{name} exists."
+            @compute_mgmt_client.virtual_machine_extensions.get(resource_group_name, virtual_machine_name, vm_extension_name)
+            Fog::Logger.debug "Virtual Machine Extension #{vm_extension_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Availability set #{name} doesn't exist."
+              Fog::Logger.debug "Virtual machine #{vm_extension_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_availability_set_exists?(_resource_group, _name)
+        def check_vm_extension_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/dns/check_record_set_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_record_set_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module Compute
+  module DNS
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_vm_exists?(resource_group, name)
-          msg = "Checking Virtual Machine #{name}"
+        def check_record_set_exists(resource_group, name, zone_name, record_type)
+          msg = "Checking Record set #{name}"
           Fog::Logger.debug msg
           begin
-            @compute_mgmt_client.virtual_machines.get(resource_group, name, 'instanceView')
-            Fog::Logger.debug "Virtual machine #{name} exists."
+            @dns_client.record_sets.get(resource_group, zone_name, name, record_type)
+            Fog::Logger.debug "Record set #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Virtual machine #{name} doesn't exist."
+            if e.body['code'] == 'NotFound'
+              Fog::Logger.debug "Record set #{name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_vm_exists?(_resource_group, _name)
+        def check_record_set_exists(_resource_group, _name)
           true
         end
       end

--- a/lib/fog/azurerm/requests/dns/check_zone_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_zone_exists.rb
@@ -10,6 +10,8 @@ module Fog
             zone = @dns_client.zones.get(resource_group, name)
           rescue MsRestAzure::AzureOperationError => e
             raise_azure_exception(e, msg)
+          rescue => e
+            Fog::Logger.debug e[:error][:code]
           end
           !zone.nil?
         end

--- a/lib/fog/azurerm/requests/dns/check_zone_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_zone_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # Real class for DNS Request
       class Real
-        def check_zone_exists?(resource_group, name)
+        def check_zone_exists(resource_group, name)
           msg = "Getting Zone #{name} from Resource Group #{resource_group}."
           Fog::Logger.debug msg
           begin
@@ -17,7 +17,7 @@ module Fog
 
       # Mock class for DNS Request
       class Mock
-        def check_zone_exists?(*)
+        def check_zone_exists(*)
           Fog::Logger.debug 'Zone name name is available.'
           true
         end

--- a/lib/fog/azurerm/requests/key_vault/check_vault_exists.rb
+++ b/lib/fog/azurerm/requests/key_vault/check_vault_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module ApplicationGateway
+  module KeyVault
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_ag_exists?(resource_group_name, application_gateway_name)
-          msg = "Checking Application Gateway: #{application_gateway_name}"
+        def check_vault_exists(resource_group, vault_name)
+          msg = "Checking Vault #{vault_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.application_gateways.get(resource_group_name, application_gateway_name)
-            Fog::Logger.debug "Application Gateway #{application_gateway_name} exists."
+            @key_vault_client.vaults.get(resource_group, vault_name)
+            Fog::Logger.debug "Vault #{vault_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Application Gateway #{application_gateway_name} doesn't exist."
+              Fog::Logger.debug "Vault #{vault_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_ag_exists?(*)
+        def check_vault_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_express_route_cir_auth_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_express_route_cir_auth_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_local_net_gateway_exists?(resource_group_name, local_network_gateway_name)
-          msg = "Checking Local Network Gateway #{local_network_gateway_name}"
+        def check_express_route_cir_auth_exists(resource_group_name, circuit_name, authorization_name)
+          msg = "Checking Express Route Circuit Authorization #{authorization_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.local_network_gateways.get(resource_group_name, local_network_gateway_name)
-            Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} exists."
+            @network_client.express_route_circuit_authorizations.get(resource_group_name, circuit_name, authorization_name)
+            Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} doesn't exist."
+              Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_local_net_gateway_exists?(*)
+        def check_express_route_cir_auth_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_express_route_circuit_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_express_route_circuit_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_net_sec_group_exists?(resource_group_name, security_group_name)
-          msg = "Checking Network Security Group #{security_group_name}"
+        def check_express_route_circuit_exists(resource_group_name, circuit_name)
+          msg = "Checking Express Route Circuit #{circuit_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.network_security_groups.get(resource_group_name, security_group_name)
-            Fog::Logger.debug "Network Security Group #{security_group_name} exists."
+            @network_client.express_route_circuits.get(resource_group_name, circuit_name)
+            Fog::Logger.debug "Express Route Circuit #{circuit_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Network Security Group #{security_group_name} doesn't exist."
+              Fog::Logger.debug "Express Route Circuit #{circuit_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_net_sec_group_exists?(*)
+        def check_express_route_circuit_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_load_balancer_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_load_balancer_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module Compute
+  module Network
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_vm_extension_exists?(resource_group_name, virtual_machine_name, vm_extension_name)
-          msg = "Checking Virtual Machine Extension #{vm_extension_name}"
+        def check_load_balancer_exists(resource_group_name, load_balancer_name)
+          msg = "Checking Load Balancer #{load_balancer_name}"
           Fog::Logger.debug msg
           begin
-            @compute_mgmt_client.virtual_machine_extensions.get(resource_group_name, virtual_machine_name, vm_extension_name)
-            Fog::Logger.debug "Virtual Machine Extension #{vm_extension_name} exists."
+            @network_client.load_balancers.get(resource_group_name, load_balancer_name)
+            Fog::Logger.debug "Load Balancer #{load_balancer_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Virtual machine #{vm_extension_name} doesn't exist."
+              Fog::Logger.debug "Load Balancer #{load_balancer_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_vm_extension_exists?(*)
+        def check_load_balancer_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_local_net_gateway_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_local_net_gateway_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module TrafficManager
+  module Network
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_traffic_manager_profile_exists?(resource_group, traffic_manager_profile_name)
-          msg = "Checking Traffic Manager Profile #{traffic_manager_profile_name}"
+        def check_local_net_gateway_exists(resource_group_name, local_network_gateway_name)
+          msg = "Checking Local Network Gateway #{local_network_gateway_name}"
           Fog::Logger.debug msg
           begin
-            @traffic_mgmt_client.profiles.get(resource_group, traffic_manager_profile_name)
-            Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} exists."
+            @network_client.local_network_gateways.get(resource_group_name, local_network_gateway_name)
+            Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} doesn't exist."
+              Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_traffic_manager_profile_exists?(*)
+        def check_local_net_gateway_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_net_sec_group_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_net_sec_group_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_express_route_circuit_exists?(resource_group_name, circuit_name)
-          msg = "Checking Express Route Circuit #{circuit_name}"
+        def check_net_sec_group_exists(resource_group_name, security_group_name)
+          msg = "Checking Network Security Group #{security_group_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.express_route_circuits.get(resource_group_name, circuit_name)
-            Fog::Logger.debug "Express Route Circuit #{circuit_name} exists."
+            @network_client.network_security_groups.get(resource_group_name, security_group_name)
+            Fog::Logger.debug "Network Security Group #{security_group_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Express Route Circuit #{circuit_name} doesn't exist."
+              Fog::Logger.debug "Network Security Group #{security_group_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_express_route_circuit_exists?(*)
+        def check_net_sec_group_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_net_sec_rule_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_net_sec_rule_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_express_route_cir_auth_exists?(resource_group_name, circuit_name, authorization_name)
-          msg = "Checking Express Route Circuit Authorization #{authorization_name}"
+        def check_net_sec_rule_exists(resource_group_name, network_security_group_name, security_rule_name)
+          msg = "Checking Network Security Rule #{security_rule_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.express_route_circuit_authorizations.get(resource_group_name, circuit_name, authorization_name)
-            Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} exists."
+            @network_client.security_rules.get(resource_group_name, network_security_group_name, security_rule_name)
+            Fog::Logger.debug "Network Security Rule #{security_rule_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} doesn't exist."
+              Fog::Logger.debug "Network Security Rule #{security_rule_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_express_route_cir_auth_exists?(*)
+        def check_net_sec_rule_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_network_interface_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_network_interface_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_network_interface_exists?(resource_group_name, nic_name)
+        def check_network_interface_exists(resource_group_name, nic_name)
           msg = "Checking Network Interface #{nic_name}"
           Fog::Logger.debug msg
           begin
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_network_interface_exists?(*)
+        def check_network_interface_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_public_ip_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_public_ip_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # Mock class for Network Request
       class Real
-        def check_subnet_exists?(resource_group, virtual_network_name, subnet_name)
-          msg = "Checking Subnet #{subnet_name}"
+        def check_public_ip_exists(resource_group, name)
+          msg = "Checking Public IP #{name}"
           Fog::Logger.debug msg
           begin
-            @network_client.subnets.get(resource_group, virtual_network_name, subnet_name)
-            Fog::Logger.debug "Subnet #{subnet_name} exists."
+            @network_client.public_ipaddresses.get(resource_group, name)
+            Fog::Logger.debug "Public IP #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Subnet #{subnet_name} doesn't exist."
+              Fog::Logger.debug "Public IP #{name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -23,7 +23,8 @@ module Fog
 
       # Mock class for Network Request
       class Mock
-        def check_subnet_exists?(*)
+        def check_public_ip_exists(resource_group, name)
+          Fog::Logger.debug "Public IP #{name} from Resource group #{resource_group} is available."
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_subnet_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_subnet_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # Mock class for Network Request
       class Real
-        def check_virtual_network_exists?(resource_group, name)
-          msg = "Checking Virtual Network #{name}"
+        def check_subnet_exists(resource_group, virtual_network_name, subnet_name)
+          msg = "Checking Subnet #{subnet_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.virtual_networks.get(resource_group, name)
-            Fog::Logger.debug "Virtual Network #{name} exists."
+            @network_client.subnets.get(resource_group, virtual_network_name, subnet_name)
+            Fog::Logger.debug "Subnet #{subnet_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Virtual Network #{name} doesn't exist."
+              Fog::Logger.debug "Subnet #{subnet_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -23,8 +23,7 @@ module Fog
 
       # Mock class for Network Request
       class Mock
-        def check_virtual_network_exists?(resource_group, name)
-          Fog::Logger.debug "Virtual Network #{name} from Resource group #{resource_group} is available."
+        def check_subnet_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_virtual_network_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_virtual_network_exists.rb
@@ -3,16 +3,16 @@ module Fog
     class AzureRM
       # Mock class for Network Request
       class Real
-        def check_public_ip_exists?(resource_group, name)
-          msg = "Checking Public IP #{name}"
+        def check_virtual_network_exists(resource_group, name)
+          msg = "Checking Virtual Network #{name}"
           Fog::Logger.debug msg
           begin
-            @network_client.public_ipaddresses.get(resource_group, name)
-            Fog::Logger.debug "Public IP #{name} exists."
+            @network_client.virtual_networks.get(resource_group, name)
+            Fog::Logger.debug "Virtual Network #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Public IP #{name} doesn't exist."
+              Fog::Logger.debug "Virtual Network #{name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -23,8 +23,8 @@ module Fog
 
       # Mock class for Network Request
       class Mock
-        def check_public_ip_exists?(resource_group, name)
-          Fog::Logger.debug "Public IP #{name} from Resource group #{resource_group} is available."
+        def check_virtual_network_exists(resource_group, name)
+          Fog::Logger.debug "Virtual Network #{name} from Resource group #{resource_group} is available."
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_vnet_gateway_connection_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_vnet_gateway_connection_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # Mock class for Network Request
       class Real
-        def check_vnet_gateway_connection_exists?(resource_group_name, gateway_connection_name)
+        def check_vnet_gateway_connection_exists(resource_group_name, gateway_connection_name)
           msg = "Checking Virtual Network Gateway Connection #{gateway_connection_name}"
           Fog::Logger.debug msg
           begin
@@ -23,7 +23,7 @@ module Fog
 
       # Mock class for Network Request
       class Mock
-        def check_vnet_gateway_connection_exists?(*)
+        def check_vnet_gateway_connection_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/network/check_vnet_gateway_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_vnet_gateway_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # Mock class for Network Request
       class Real
-        def check_vnet_gateway_exists?(resource_group_name, network_gateway_name)
+        def check_vnet_gateway_exists(resource_group_name, network_gateway_name)
           msg = "Checking Virtual Network Gateway #{network_gateway_name}"
           Fog::Logger.debug msg
           begin
@@ -23,7 +23,7 @@ module Fog
 
       # Mock class for Network Request
       class Mock
-        def check_vnet_gateway_exists?(*)
+        def check_vnet_gateway_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/resources/check_azure_resource_exists.rb
+++ b/lib/fog/azurerm/requests/resources/check_azure_resource_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_azure_resource_exists?(resource_id, api_version)
+        def check_azure_resource_exists(resource_id, api_version)
           split_resource = resource_id.split('/') unless resource_id.nil?
           raise 'Invalid Resource Id' if split_resource.count != 9
 
@@ -31,7 +31,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_azure_resource_exists?(*)
+        def check_azure_resource_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/resources/check_deployment_exists.rb
+++ b/lib/fog/azurerm/requests/resources/check_deployment_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_deployment_exists?(resource_group_name, deployment_name)
+        def check_deployment_exists(resource_group_name, deployment_name)
           msg = "Checking Deployment #{deployment_name}"
           Fog::Logger.debug msg
           begin
@@ -21,7 +21,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_deployment_exists?(*)
+        def check_deployment_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/resources/check_resource_group_exists.rb
+++ b/lib/fog/azurerm/requests/resources/check_resource_group_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_resource_group_exists?(resource_group_name)
+        def check_resource_group_exists(resource_group_name)
           msg = "Checking Resource Group #{resource_group_name}"
           Fog::Logger.debug msg
           begin
@@ -21,7 +21,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_resource_group_exists?(*)
+        def check_resource_group_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/sql/check_database_exists.rb
+++ b/lib/fog/azurerm/requests/sql/check_database_exists.rb
@@ -3,8 +3,8 @@ module Fog
     class AzureRM
       # Mock class for Sql Request
       class Real
-        def check_sql_server_exists?(resource_group, server_name)
-          msg = "Checking SQL Server #{server_name}"
+        def check_database_exists(resource_group, server_name, name)
+          msg = "Checking SQL Database #{name}"
           Fog::Logger.debug msg
           # This module needs to be updated to azure sdk
         end
@@ -12,7 +12,7 @@ module Fog
 
       # Mock class for Sql Request
       class Mock
-        def check_sql_server_exists?(*)
+        def check_database_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/sql/check_firewall_rule_exists.rb
+++ b/lib/fog/azurerm/requests/sql/check_firewall_rule_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # Mock class for Sql Request
       class Real
-        def check_firewall_rule_exists?(resource_group, server_name, rule_name)
+        def check_firewall_rule_exists(resource_group, server_name, rule_name)
           msg = "Checking Firewall Rule #{rule_name}"
           Fog::Logger.debug msg
           # This module needs to be updated to azure sdk
@@ -12,7 +12,7 @@ module Fog
 
       # Mock class for Sql Request
       class Mock
-        def check_firewall_rule_exists?(*)
+        def check_firewall_rule_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/sql/check_sql_server_exists.rb
+++ b/lib/fog/azurerm/requests/sql/check_sql_server_exists.rb
@@ -3,8 +3,8 @@ module Fog
     class AzureRM
       # Mock class for Sql Request
       class Real
-        def check_database_exists?(resource_group, server_name, name)
-          msg = "Checking SQL Database #{name}"
+        def check_sql_server_exists(resource_group, server_name)
+          msg = "Checking SQL Server #{server_name}"
           Fog::Logger.debug msg
           # This module needs to be updated to azure sdk
         end
@@ -12,7 +12,7 @@ module Fog
 
       # Mock class for Sql Request
       class Mock
-        def check_database_exists?(*)
+        def check_sql_server_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/storage/check_container_exists.rb
+++ b/lib/fog/azurerm/requests/storage/check_container_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_container_exists?(name)
+        def check_container_exists(name)
           msg = "Checking container #{name}."
           Fog::Logger.debug msg
           begin
@@ -21,7 +21,7 @@ module Fog
 
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_container_exists?(*)
+        def check_container_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/storage/check_storage_account_exists.rb
+++ b/lib/fog/azurerm/requests/storage/check_storage_account_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_storage_account_exists?(resource_group_name, storage_account_name)
+        def check_storage_account_exists(resource_group_name, storage_account_name)
           msg = "Checking Storage Account: #{storage_account_name}."
           Fog::Logger.debug msg
           begin
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation.
       class Mock
-        def check_storage_account_exists?(*)
+        def check_storage_account_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_endpoint_exists.rb
+++ b/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_endpoint_exists.rb
@@ -3,7 +3,7 @@ module Fog
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_traffic_manager_endpoint_exists?(resource_group, traffic_manager_profile_name, traffic_manager_end_point, type)
+        def check_traffic_manager_endpoint_exists(resource_group, traffic_manager_profile_name, traffic_manager_end_point, type)
           msg = "Checking Traffic Manager Endpoint #{traffic_manager_end_point}"
           Fog::Logger.debug msg
           begin
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_traffic_manager_endpoint_exists?(*)
+        def check_traffic_manager_endpoint_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_profile_exists.rb
+++ b/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_profile_exists.rb
@@ -1,18 +1,18 @@
 module Fog
-  module Network
+  module TrafficManager
     class AzureRM
       # This class provides the actual implementation for service calls.
       class Real
-        def check_load_balancer_exists?(resource_group_name, load_balancer_name)
-          msg = "Checking Load Balancer #{load_balancer_name}"
+        def check_traffic_manager_profile_exists(resource_group, traffic_manager_profile_name)
+          msg = "Checking Traffic Manager Profile #{traffic_manager_profile_name}"
           Fog::Logger.debug msg
           begin
-            @network_client.load_balancers.get(resource_group_name, load_balancer_name)
-            Fog::Logger.debug "Load Balancer #{load_balancer_name} exists."
+            @traffic_mgmt_client.profiles.get(resource_group, traffic_manager_profile_name)
+            Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
             if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Load Balancer #{load_balancer_name} doesn't exist."
+              Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} doesn't exist."
               false
             else
               raise_azure_exception(e, msg)
@@ -22,7 +22,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_load_balancer_exists?(*)
+        def check_traffic_manager_profile_exists(*)
           true
         end
       end

--- a/lib/fog/azurerm/resources.rb
+++ b/lib/fog/azurerm/resources.rb
@@ -13,16 +13,16 @@ module Fog
       request :list_resource_groups
       request :delete_resource_group
       request :get_resource_group
-      request :check_resource_group_exists?
+      request :check_resource_group_exists
       request :create_deployment
       request :delete_deployment
       request :list_deployments
       request :get_deployment
-      request :check_deployment_exists?
+      request :check_deployment_exists
       request :delete_resource_tag
       request :list_tagged_resources
       request :tag_resource
-      request :check_azure_resource_exists?
+      request :check_azure_resource_exists
 
       model_path 'fog/azurerm/models/resources'
       model :resource_group

--- a/lib/fog/azurerm/sql.rb
+++ b/lib/fog/azurerm/sql.rb
@@ -13,19 +13,19 @@ module Fog
       request :delete_sql_server
       request :get_sql_server
       request :list_sql_servers
-      request :check_sql_server_exists?
+      request :check_sql_server_exists
 
       request :create_or_update_database
       request :delete_database
       request :get_database
       request :list_databases
-      request :check_database_exists?
+      request :check_database_exists
 
       request :create_or_update_firewall_rule
       request :delete_firewall_rule
       request :get_firewall_rule
       request :list_firewall_rules
-      request :check_firewall_rule_exists?
+      request :check_firewall_rule_exists
 
       model_path 'fog/azurerm/models/sql'
       model :sql_server

--- a/lib/fog/azurerm/storage.rb
+++ b/lib/fog/azurerm/storage.rb
@@ -24,7 +24,7 @@ module Fog
       request :list_storage_account_for_rg
       request :check_storage_account_name_availability
       request :get_storage_access_keys
-      request :check_storage_account_exists?
+      request :check_storage_account_exists
       # Azure Storage Disk requests
       request :delete_disk
       request :create_disk
@@ -39,7 +39,7 @@ module Fog
       request :get_container_acl
       request :put_container_acl
       request :get_container_url
-      request :check_container_exists?
+      request :check_container_exists
       # Azure Storage Blob requests
       request :list_blobs
       request :put_blob_metadata

--- a/lib/fog/azurerm/traffic_manager.rb
+++ b/lib/fog/azurerm/traffic_manager.rb
@@ -13,12 +13,12 @@ module Fog
       request :delete_traffic_manager_profile
       request :get_traffic_manager_profile
       request :list_traffic_manager_profiles
-      request :check_traffic_manager_profile_exists?
+      request :check_traffic_manager_profile_exists
 
       request :create_or_update_traffic_manager_endpoint
       request :delete_traffic_manager_endpoint
       request :get_traffic_manager_endpoint
-      request :check_traffic_manager_endpoint_exists?
+      request :check_traffic_manager_endpoint_exists
 
       model_path 'fog/azurerm/models/traffic_manager'
       model :traffic_manager_profile

--- a/test/integration/Virtual_network_gateway_connection.rb
+++ b/test/integration/Virtual_network_gateway_connection.rb
@@ -155,9 +155,8 @@ begin
   ######################            Check Virtual Network Gateway Connection Exists                 ######################
   ########################################################################################################################
 
-  if !network.virtual_network_gateway_connections.check_vnet_gateway_connection_exists('TestRG-GC', 'testnetworkgateway2-to-testnetworkgateway')
-    puts "Virtual Network Gateway Connection doesn't exist."
-  end
+  flag = network.virtual_network_gateway_connections.check_vnet_gateway_connection_exists('TestRG-GC', 'testnetworkgateway2-to-testnetworkgateway')
+  puts "Virtual Network Gateway Connection doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                           Create Virtual Network Gateway Connection                   ###########

--- a/test/integration/Virtual_network_gateway_connection.rb
+++ b/test/integration/Virtual_network_gateway_connection.rb
@@ -155,7 +155,7 @@ begin
   ######################            Check Virtual Network Gateway Connection Exists                 ######################
   ########################################################################################################################
 
-  if !network.virtual_network_gateway_connections.check_vnet_gateway_connection_exists?('TestRG-GC', 'testnetworkgateway2-to-testnetworkgateway')
+  if !network.virtual_network_gateway_connections.check_vnet_gateway_connection_exists('TestRG-GC', 'testnetworkgateway2-to-testnetworkgateway')
     puts "Virtual Network Gateway Connection doesn't exist."
   end
 

--- a/test/integration/application_gateway.rb
+++ b/test/integration/application_gateway.rb
@@ -75,7 +75,7 @@ begin
   ######################                            Check for Application Gateway                   ######################
   ########################################################################################################################
 
-  if !application_gateway.gateways.check_application_gateway_exists?(resource_group_name, app_gateway_name)
+  if !application_gateway.gateways.check_application_gateway_exists(resource_group_name, app_gateway_name)
     puts "Application Gateway doesn't exist."
   end
 

--- a/test/integration/application_gateway.rb
+++ b/test/integration/application_gateway.rb
@@ -75,9 +75,8 @@ begin
   ######################                            Check for Application Gateway                   ######################
   ########################################################################################################################
 
-  if !application_gateway.gateways.check_application_gateway_exists(resource_group_name, app_gateway_name)
-    puts "Application Gateway doesn't exist."
-  end
+  flag = application_gateway.gateways.check_application_gateway_exists(resource_group_name, app_gateway_name)
+  puts "Application Gateway doesn't exist." unless flag
 
   #######################################################################################################################
   #####################                          Create Application Gateway                        ######################

--- a/test/integration/availability_set.rb
+++ b/test/integration/availability_set.rb
@@ -47,9 +47,8 @@ begin
   ######################                            Check for Availability set                       ######################
   ########################################################################################################################
 
-  if !compute.availability_sets.check_availability_set_exists(resource_group_name, availability_set_name)
-    puts "Availability set doesn't exist."
-  end
+  flag = compute.availability_sets.check_availability_set_exists(resource_group_name, availability_set_name)
+  puts "Availability set doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                             Create Availability Set                        ######################

--- a/test/integration/availability_set.rb
+++ b/test/integration/availability_set.rb
@@ -47,7 +47,7 @@ begin
   ######################                            Check for Availability set                       ######################
   ########################################################################################################################
 
-  if !compute.availability_sets.check_availability_set_exists?(resource_group_name, availability_set_name)
+  if !compute.availability_sets.check_availability_set_exists(resource_group_name, availability_set_name)
     puts "Availability set doesn't exist."
   end
 

--- a/test/integration/container.rb
+++ b/test/integration/container.rb
@@ -64,7 +64,7 @@ begin
   ######################                             Check Container Exists                         ######################
   ########################################################################################################################
 
-  if !storage_data.directories.check_container_exists?(container_name)
+  if !storage_data.directories.check_container_exists(container_name)
     puts "Container doesn't exist."
   end
 

--- a/test/integration/container.rb
+++ b/test/integration/container.rb
@@ -64,9 +64,8 @@ begin
   ######################                             Check Container Exists                         ######################
   ########################################################################################################################
 
-  if !storage_data.directories.check_container_exists(container_name)
-    puts "Container doesn't exist."
-  end
+  flag = storage_data.directories.check_container_exists(container_name)
+  puts "Container doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Create Container                            ######################

--- a/test/integration/deployment.rb
+++ b/test/integration/deployment.rb
@@ -29,9 +29,8 @@ begin
   ######################                            Check Deployment Exists                         ######################
   ########################################################################################################################
 
-  if !resources.deployments.check_deployment_exists('TestRG-ZN', 'testdeployment')
-    puts "Deployment doesn't exist."
-  end
+  flag = resources.deployments.check_deployment_exists('TestRG-ZN', 'testdeployment')
+  puts "Deployment doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Create Deployment                     ############################

--- a/test/integration/deployment.rb
+++ b/test/integration/deployment.rb
@@ -29,7 +29,7 @@ begin
   ######################                            Check Deployment Exists                         ######################
   ########################################################################################################################
 
-  if !resources.deployments.check_deployment_exists?('TestRG-ZN', 'testdeployment')
+  if !resources.deployments.check_deployment_exists('TestRG-ZN', 'testdeployment')
     puts "Deployment doesn't exist."
   end
 

--- a/test/integration/express_route_circuit.rb
+++ b/test/integration/express_route_circuit.rb
@@ -37,7 +37,7 @@ begin
   ######################                  Check Express Route Circuit Exists?                       ######################
   ########################################################################################################################
 
-  if !network.express_route_circuits.check_express_route_circuit_exists?('TestRG-ER', 'testERCircuit')
+  if !network.express_route_circuits.check_express_route_circuit_exists('TestRG-ER', 'testERCircuit')
     puts "Express Route Circuit doesn't exist."
   end
 
@@ -86,7 +86,7 @@ begin
   ######################             Check Express Route Circuit Authorization Exists?              ######################
   ########################################################################################################################
 
-  if !network.express_route_circuit_authorizations.check_express_route_cir_auth_exists?('TestRG-ER', 'testERCircuit', 'Test-Auth')
+  if !network.express_route_circuit_authorizations.check_express_route_cir_auth_exists('TestRG-ER', 'testERCircuit', 'Test-Auth')
     puts "Express Route Circuit Authorization doesn't exist."
   end
 

--- a/test/integration/express_route_circuit.rb
+++ b/test/integration/express_route_circuit.rb
@@ -37,9 +37,8 @@ begin
   ######################                  Check Express Route Circuit Exists?                       ######################
   ########################################################################################################################
 
-  if !network.express_route_circuits.check_express_route_circuit_exists('TestRG-ER', 'testERCircuit')
-    puts "Express Route Circuit doesn't exist."
-  end
+  flag = network.express_route_circuits.check_express_route_circuit_exists('TestRG-ER', 'testERCircuit')
+  puts "Express Route Circuit doesn't exist." unless flag
 
   ########################################################################################################################
   ################                               Create Express Route Circuit                            #################
@@ -86,9 +85,8 @@ begin
   ######################             Check Express Route Circuit Authorization Exists?              ######################
   ########################################################################################################################
 
-  if !network.express_route_circuit_authorizations.check_express_route_cir_auth_exists('TestRG-ER', 'testERCircuit', 'Test-Auth')
-    puts "Express Route Circuit Authorization doesn't exist."
-  end
+  flag = network.express_route_circuit_authorizations.check_express_route_cir_auth_exists('TestRG-ER', 'testERCircuit', 'Test-Auth')
+  puts "Express Route Circuit Authorization doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                Create Express Route Circuit Authorizations                   ####################

--- a/test/integration/external_load_balancer.rb
+++ b/test/integration/external_load_balancer.rb
@@ -58,9 +58,8 @@ begin
   ######################                      Check Load Balancer Exists?                           ######################
   ########################################################################################################################
 
-  if !network.load_balancers.check_load_balancer_exists('TestRG-LB', 'lb')
-    puts "Load Balancer doesn't exist."
-  end
+  flag = network.load_balancers.check_load_balancer_exists('TestRG-LB', 'lb')
+  puts "Load Balancer doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                             Create Load Balancer                           ######################

--- a/test/integration/external_load_balancer.rb
+++ b/test/integration/external_load_balancer.rb
@@ -58,7 +58,7 @@ begin
   ######################                      Check Load Balancer Exists?                           ######################
   ########################################################################################################################
 
-  if !network.load_balancers.check_load_balancer_exists?('TestRG-LB', 'lb')
+  if !network.load_balancers.check_load_balancer_exists('TestRG-LB', 'lb')
     puts "Load Balancer doesn't exist."
   end
 

--- a/test/integration/key_vault.rb
+++ b/test/integration/key_vault.rb
@@ -36,9 +36,8 @@ begin
   ######################                      Check Key Vault Exists?                               ######################
   ########################################################################################################################
 
-  if !key_vault.vaults.check_vault_exists('TestRG-KV', 'test-tmp')
-    puts "Key vault doesn't exist."
-  end
+  flag = key_vault.vaults.check_vault_exists('TestRG-KV', 'test-tmp')
+  puts "Key vault doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                         Create Vault                                       ######################

--- a/test/integration/key_vault.rb
+++ b/test/integration/key_vault.rb
@@ -36,7 +36,7 @@ begin
   ######################                      Check Key Vault Exists?                               ######################
   ########################################################################################################################
 
-  if !key_vault.vaults.check_vault_exists?('TestRG-KV', 'test-tmp')
+  if !key_vault.vaults.check_vault_exists('TestRG-KV', 'test-tmp')
     puts "Key vault doesn't exist."
   end
 

--- a/test/integration/local_network_gateway.rb
+++ b/test/integration/local_network_gateway.rb
@@ -36,9 +36,8 @@ begin
   ######################                   Check Local Network Gateway Exists?                      ######################
   ########################################################################################################################
 
-  if !network.local_network_gateways.check_local_net_gateway_exists('TestRG-LNG', 'testlocalnetworkgateway')
-    puts "Local Network Gateway doesn't exist."
-  end
+  flag = network.local_network_gateways.check_local_net_gateway_exists('TestRG-LNG', 'testlocalnetworkgateway')
+  puts "Local Network Gateway doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                           Create Local Network Gateway                   ######################

--- a/test/integration/local_network_gateway.rb
+++ b/test/integration/local_network_gateway.rb
@@ -36,7 +36,7 @@ begin
   ######################                   Check Local Network Gateway Exists?                      ######################
   ########################################################################################################################
 
-  if !network.local_network_gateways.check_local_net_gateway_exists?('TestRG-LNG', 'testlocalnetworkgateway')
+  if !network.local_network_gateways.check_local_net_gateway_exists('TestRG-LNG', 'testlocalnetworkgateway')
     puts "Local Network Gateway doesn't exist."
   end
 

--- a/test/integration/network_interface.rb
+++ b/test/integration/network_interface.rb
@@ -91,7 +91,7 @@ begin
   ######################                      Check Network Interface Exists?                       ######################
   ########################################################################################################################
 
-  if !network.network_interfaces.check_network_interface_exists?('TestRG-NI', 'NetInt')
+  if !network.network_interfaces.check_network_interface_exists('TestRG-NI', 'NetInt')
     puts "Network Interface doesn't exist."
   end
 

--- a/test/integration/network_interface.rb
+++ b/test/integration/network_interface.rb
@@ -91,9 +91,8 @@ begin
   ######################                      Check Network Interface Exists?                       ######################
   ########################################################################################################################
 
-  if !network.network_interfaces.check_network_interface_exists('TestRG-NI', 'NetInt')
-    puts "Network Interface doesn't exist."
-  end
+  flag = network.network_interfaces.check_network_interface_exists('TestRG-NI', 'NetInt')
+  puts "Network Interface doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                           Create Network Interface                         ######################

--- a/test/integration/network_security_group.rb
+++ b/test/integration/network_security_group.rb
@@ -36,7 +36,7 @@ begin
   ######################                  Check Network Security Group Exists?                      ######################
   ########################################################################################################################
 
-  if !network.network_security_groups.check_net_sec_group_exists?('TestRG-NSG', 'testGroup')
+  if !network.network_security_groups.check_net_sec_group_exists('TestRG-NSG', 'testGroup')
     puts "Network Security Group doesn't exist."
   end
 

--- a/test/integration/network_security_group.rb
+++ b/test/integration/network_security_group.rb
@@ -36,9 +36,8 @@ begin
   ######################                  Check Network Security Group Exists?                      ######################
   ########################################################################################################################
 
-  if !network.network_security_groups.check_net_sec_group_exists('TestRG-NSG', 'testGroup')
-    puts "Network Security Group doesn't exist."
-  end
+  flag = network.network_security_groups.check_net_sec_group_exists('TestRG-NSG', 'testGroup')
+  puts "Network Security Group doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                          Create Network Security Group                     ######################

--- a/test/integration/network_security_rule.rb
+++ b/test/integration/network_security_rule.rb
@@ -46,9 +46,8 @@ begin
   ######################                  Check Network Security Rule Exists?                       ######################
   ########################################################################################################################
 
-  if !network.network_security_rules.check_net_sec_rule_exists('TestRG-NSR', 'testGroup', 'testRule')
-    puts "Network Security Rule doesn't exist."
-  end
+  flag = network.network_security_rules.check_net_sec_rule_exists('TestRG-NSR', 'testGroup', 'testRule')
+  puts "Network Security Rule doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                          Create Network Security Rule                      ######################

--- a/test/integration/network_security_rule.rb
+++ b/test/integration/network_security_rule.rb
@@ -46,7 +46,7 @@ begin
   ######################                  Check Network Security Rule Exists?                       ######################
   ########################################################################################################################
 
-  if !network.network_security_rules.check_net_sec_rule_exists?('TestRG-NSR', 'testGroup', 'testRule')
+  if !network.network_security_rules.check_net_sec_rule_exists('TestRG-NSR', 'testGroup', 'testRule')
     puts "Network Security Rule doesn't exist."
   end
 

--- a/test/integration/public_ip.rb
+++ b/test/integration/public_ip.rb
@@ -36,7 +36,7 @@ begin
   ######################                               Check PublicIP exists                        ######################
   ########################################################################################################################
 
-  if !network.public_ips.check_public_ip_exists?('TestRG-PB', 'mypubip')
+  if !network.public_ips.check_public_ip_exists('TestRG-PB', 'mypubip')
     puts "Public IP doesn't exist."
   end
 

--- a/test/integration/public_ip.rb
+++ b/test/integration/public_ip.rb
@@ -36,9 +36,8 @@ begin
   ######################                               Check PublicIP exists                        ######################
   ########################################################################################################################
 
-  if !network.public_ips.check_public_ip_exists('TestRG-PB', 'mypubip')
-    puts "Public IP doesn't exist."
-  end
+  flag = network.public_ips.check_public_ip_exists('TestRG-PB', 'mypubip')
+  puts "Public IP doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                               Create Public IP                             ######################

--- a/test/integration/record_set.rb
+++ b/test/integration/record_set.rb
@@ -42,7 +42,7 @@ begin
   ######################                      Check Record Set Exists?                              ######################
   ########################################################################################################################
 
-  if !dns.record_sets.check_record_set_exists?('TestRG-RS', 'TestRS1', 'test-zone.com', 'CNAME')
+  if !dns.record_sets.check_record_set_exists('TestRG-RS', 'TestRS1', 'test-zone.com', 'CNAME')
     puts "Record set doesn't exist."
   end
 

--- a/test/integration/record_set.rb
+++ b/test/integration/record_set.rb
@@ -42,9 +42,8 @@ begin
   ######################                      Check Record Set Exists?                              ######################
   ########################################################################################################################
 
-  if !dns.record_sets.check_record_set_exists('TestRG-RS', 'TestRS1', 'test-zone.com', 'CNAME')
-    puts "Record set doesn't exist."
-  end
+  flag = dns.record_sets.check_record_set_exists('TestRG-RS', 'TestRS1', 'test-zone.com', 'CNAME')
+  puts "Record set doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                      Create CNAME Type Record Set in a Zone                 ######################

--- a/test/integration/resource_group.rb
+++ b/test/integration/resource_group.rb
@@ -22,9 +22,8 @@ begin
   ######################                   Check Resource Group Exists?                             ######################
   ########################################################################################################################
 
-  if !resource.resource_groups.check_resource_group_exists(resource_group_name)
-    puts "Resource Group doesn't exist."
-  end
+  flag = resource.resource_groups.check_resource_group_exists(resource_group_name)
+  puts "Resource Group doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                    Create Resource Group                                   ######################

--- a/test/integration/resource_group.rb
+++ b/test/integration/resource_group.rb
@@ -22,7 +22,7 @@ begin
   ######################                   Check Resource Group Exists?                             ######################
   ########################################################################################################################
 
-  if !resource.resource_groups.check_resource_group_exists?(resource_group_name)
+  if !resource.resource_groups.check_resource_group_exists(resource_group_name)
     puts "Resource Group doesn't exist."
   end
 

--- a/test/integration/resource_tag.rb
+++ b/test/integration/resource_tag.rb
@@ -43,9 +43,8 @@ begin
   ######################                   Check Azure Resource Exists?                             ######################
   ########################################################################################################################
 
-  if !resources.azure_resources.check_azure_resource_exists(resource_id, '2016-09-01')
-    puts "Azure Resource doesn't exist."
-  end
+  flag = resources.azure_resources.check_azure_resource_exists(resource_id, '2016-09-01')
+  puts "Azure Resource doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Tag Resource                          ############################

--- a/test/integration/resource_tag.rb
+++ b/test/integration/resource_tag.rb
@@ -43,7 +43,7 @@ begin
   ######################                   Check Azure Resource Exists?                             ######################
   ########################################################################################################################
 
-  if !resources.azure_resources.check_azure_resource_exists?(resource_id, '2016-09-01')
+  if !resources.azure_resources.check_azure_resource_exists(resource_id, '2016-09-01')
     puts "Azure Resource doesn't exist."
   end
 

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -83,7 +83,7 @@ begin
   ######################                            Check for Virtual Machine                       ######################
   ########################################################################################################################
 
-  if !compute.servers.check_vm_exists?('TestRG-VM', 'TestVM')
+  if !compute.servers.check_vm_exists('TestRG-VM', 'TestVM')
     puts "Virtual Machine doesn't exist."
   end
 

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -83,9 +83,8 @@ begin
   ######################                            Check for Virtual Machine                       ######################
   ########################################################################################################################
 
-  if !compute.servers.check_vm_exists('TestRG-VM', 'TestVM')
-    puts "Virtual Machine doesn't exist."
-  end
+  flag = compute.servers.check_vm_exists('TestRG-VM', 'TestVM')
+  puts "Virtual Machine doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Create Server                               ######################

--- a/test/integration/sql_server.rb
+++ b/test/integration/sql_server.rb
@@ -37,7 +37,7 @@ begin
   ########################################################################################################################
   server_name = rand(0...999_99)
 
-  if !azure_sql_service.sql_servers.check_sql_server_exists?('TestRG-SQL', server_name)
+  if !azure_sql_service.sql_servers.check_sql_server_exists('TestRG-SQL', server_name)
     puts "SQL Server doesn't exist."
   end
 
@@ -60,7 +60,7 @@ begin
   ########################################################################################################################
   database_name = rand(0...999_99)
 
-  if !azure_sql_service.sql_databases.check_database_exists?('TestRG-SQL', server_name, database_name)
+  if !azure_sql_service.sql_databases.check_database_exists('TestRG-SQL', server_name, database_name)
     puts "SQL Database doesn't exist."
   end
 
@@ -104,7 +104,7 @@ begin
   ######################                   Check Firewall Rule Exists?                              ######################
   ########################################################################################################################
 
-  if !azure_sql_service.firewall_rules.check_firewall_rule_exists?('TestRG-SQL', server_name, 'test-rule-name')
+  if !azure_sql_service.firewall_rules.check_firewall_rule_exists('TestRG-SQL', server_name, 'test-rule-name')
     puts "Firewall Rule doesn't exist."
   end
 

--- a/test/integration/sql_server.rb
+++ b/test/integration/sql_server.rb
@@ -37,9 +37,8 @@ begin
   ########################################################################################################################
   server_name = rand(0...999_99)
 
-  if !azure_sql_service.sql_servers.check_sql_server_exists('TestRG-SQL', server_name)
-    puts "SQL Server doesn't exist."
-  end
+  flag = azure_sql_service.sql_servers.check_sql_server_exists('TestRG-SQL', server_name)
+  puts "SQL Server doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                         Create Sql Server                                  ######################
@@ -60,9 +59,8 @@ begin
   ########################################################################################################################
   database_name = rand(0...999_99)
 
-  if !azure_sql_service.sql_databases.check_database_exists('TestRG-SQL', server_name, database_name)
-    puts "SQL Database doesn't exist."
-  end
+  flag = azure_sql_service.sql_databases.check_database_exists('TestRG-SQL', server_name, database_name)
+  puts "SQL Database doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                        Create Sql Database                                 ######################
@@ -104,9 +102,8 @@ begin
   ######################                   Check Firewall Rule Exists?                              ######################
   ########################################################################################################################
 
-  if !azure_sql_service.firewall_rules.check_firewall_rule_exists('TestRG-SQL', server_name, 'test-rule-name')
-    puts "Firewall Rule doesn't exist."
-  end
+  flag = azure_sql_service.firewall_rules.check_firewall_rule_exists('TestRG-SQL', server_name, 'test-rule-name')
+  puts "Firewall Rule doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                        Create Sql Firewall Rule                            ######################

--- a/test/integration/storage_account.rb
+++ b/test/integration/storage_account.rb
@@ -47,7 +47,7 @@ begin
 
   lrs_storage_account = "lrs#{current_time}"
 
-  if !storage.storage_accounts.check_storage_account_exists?('TestRG-SA', lrs_storage_account)
+  if !storage.storage_accounts.check_storage_account_exists('TestRG-SA', lrs_storage_account)
     puts "Storage Account doesn't exist."
   end
 

--- a/test/integration/storage_account.rb
+++ b/test/integration/storage_account.rb
@@ -47,9 +47,8 @@ begin
 
   lrs_storage_account = "lrs#{current_time}"
 
-  if !storage.storage_accounts.check_storage_account_exists('TestRG-SA', lrs_storage_account)
-    puts "Storage Account doesn't exist."
-  end
+  flag = storage.storage_accounts.check_storage_account_exists('TestRG-SA', lrs_storage_account)
+  puts "Storage Account doesn't exist." unless flag
 
   ########################################################################################################################
   ###############  Create A Standard Storage Account of Replication: LRS (Locally-redundant storage)       ###############

--- a/test/integration/subnet.rb
+++ b/test/integration/subnet.rb
@@ -50,9 +50,8 @@ begin
   ######################                         Check Subnet Exists?                               ######################
   ########################################################################################################################
 
-  if !network.subnets.check_subnet_exists('TestRG-SN', 'testVnet', 'mysubnet')
-    puts "Subnet doesn't exist."
-  end
+  flag = network.subnets.check_subnet_exists('TestRG-SN', 'testVnet', 'mysubnet')
+  puts "Subnet doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Create Subnet                               ######################

--- a/test/integration/subnet.rb
+++ b/test/integration/subnet.rb
@@ -50,7 +50,7 @@ begin
   ######################                         Check Subnet Exists?                               ######################
   ########################################################################################################################
 
-  if !network.subnets.check_subnet_exists?('TestRG-SN', 'testVnet', 'mysubnet')
+  if !network.subnets.check_subnet_exists('TestRG-SN', 'testVnet', 'mysubnet')
     puts "Subnet doesn't exist."
   end
 

--- a/test/integration/traffic_manager.rb
+++ b/test/integration/traffic_manager.rb
@@ -36,9 +36,8 @@ begin
   ######################                   Check Traffic Manager Profile Exists?                    ######################
   ########################################################################################################################
 
-  if !traffic_manager.traffic_manager_profiles.check_traffic_manager_profile_exists('TestRG-TM', 'test-tmp')
-    puts "Traffic Manager Profile doesn't exist."
-  end
+  flag = traffic_manager.traffic_manager_profiles.check_traffic_manager_profile_exists('TestRG-TM', 'test-tmp')
+  puts "Traffic Manager Profile doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                         Create Traffic Manager Profile                     ######################
@@ -60,9 +59,8 @@ begin
   ######################                   Check Traffic Manager Endpoint Exists?                   ######################
   ########################################################################################################################
 
-  if !traffic_manager.traffic_manager_end_points.check_traffic_manager_endpoint_exists('TestRG-TM', 'test-tmp', 'myendpoint', 'externalEndpoints')
-    puts "Traffic Manager Endpoint doesn't exist."
-  end
+  flag = traffic_manager.traffic_manager_end_points.check_traffic_manager_endpoint_exists('TestRG-TM', 'test-tmp', 'myendpoint', 'externalEndpoints')
+  puts "Traffic Manager Endpoint doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                        Create Traffic Manager Endpoint                    ######################

--- a/test/integration/traffic_manager.rb
+++ b/test/integration/traffic_manager.rb
@@ -36,7 +36,7 @@ begin
   ######################                   Check Traffic Manager Profile Exists?                    ######################
   ########################################################################################################################
 
-  if !traffic_manager.traffic_manager_profiles.check_traffic_manager_profile_exists?('TestRG-TM', 'test-tmp')
+  if !traffic_manager.traffic_manager_profiles.check_traffic_manager_profile_exists('TestRG-TM', 'test-tmp')
     puts "Traffic Manager Profile doesn't exist."
   end
 
@@ -60,7 +60,7 @@ begin
   ######################                   Check Traffic Manager Endpoint Exists?                   ######################
   ########################################################################################################################
 
-  if !traffic_manager.traffic_manager_end_points.check_traffic_manager_endpoint_exists?('TestRG-TM', 'test-tmp', 'myendpoint', 'externalEndpoints')
+  if !traffic_manager.traffic_manager_end_points.check_traffic_manager_endpoint_exists('TestRG-TM', 'test-tmp', 'myendpoint', 'externalEndpoints')
     puts "Traffic Manager Endpoint doesn't exist."
   end
 

--- a/test/integration/virtual_machine_extension.rb
+++ b/test/integration/virtual_machine_extension.rb
@@ -99,7 +99,7 @@ begin
   ######################                  Check Virtual Machine Extension Exists?                   ######################
   ########################################################################################################################
 
-  if !compute.virtual_machine_extensions.check_vm_extension_exists?('TestRG-VME', 'TestVM', 'IaasAntimalware')
+  if !compute.virtual_machine_extensions.check_vm_extension_exists('TestRG-VME', 'TestVM', 'IaasAntimalware')
     puts "Virtual machine extension doesn't exist."
   end
 

--- a/test/integration/virtual_machine_extension.rb
+++ b/test/integration/virtual_machine_extension.rb
@@ -99,9 +99,8 @@ begin
   ######################                  Check Virtual Machine Extension Exists?                   ######################
   ########################################################################################################################
 
-  if !compute.virtual_machine_extensions.check_vm_extension_exists('TestRG-VME', 'TestVM', 'IaasAntimalware')
-    puts "Virtual machine extension doesn't exist."
-  end
+  flag = compute.virtual_machine_extensions.check_vm_extension_exists('TestRG-VME', 'TestVM', 'IaasAntimalware')
+  puts "Virtual machine extension doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                         Attach Extension To Server                         ######################

--- a/test/integration/virtual_network.rb
+++ b/test/integration/virtual_network.rb
@@ -36,9 +36,8 @@ begin
   ######################                          Check Virtual Network Exists                      ######################
   ########################################################################################################################
 
-  if !network.virtual_networks.check_virtual_network_exists('TestRG-VN', 'testVnet')
-    puts "Virtual Network doesn't exist."
-  end
+  flag = network.virtual_networks.check_virtual_network_exists('TestRG-VN', 'testVnet')
+  puts "Virtual Network doesn't exist." unless flag
 
   ########################################################################################################################
   ######################            Create Virtual Network with complete parameters list            ######################

--- a/test/integration/virtual_network.rb
+++ b/test/integration/virtual_network.rb
@@ -36,7 +36,7 @@ begin
   ######################                          Check Virtual Network Exists                      ######################
   ########################################################################################################################
 
-  if !network.virtual_networks.check_virtual_network_exists?('TestRG-VN', 'testVnet')
+  if !network.virtual_networks.check_virtual_network_exists('TestRG-VN', 'testVnet')
     puts "Virtual Network doesn't exist."
   end
 

--- a/test/integration/virtual_network_gateway.rb
+++ b/test/integration/virtual_network_gateway.rb
@@ -57,7 +57,7 @@ begin
   ######################                    Check Virtual Network Gateway Exists                    ######################
   ########################################################################################################################
 
-  if !network.virtual_network_gateways.check_vnet_gateway_exists?('TestRG-VNG', 'testnetworkgateway')
+  if !network.virtual_network_gateways.check_vnet_gateway_exists('TestRG-VNG', 'testnetworkgateway')
     puts "Virtual Network Gateway doesn't exist."
   end
 

--- a/test/integration/virtual_network_gateway.rb
+++ b/test/integration/virtual_network_gateway.rb
@@ -57,9 +57,8 @@ begin
   ######################                    Check Virtual Network Gateway Exists                    ######################
   ########################################################################################################################
 
-  if !network.virtual_network_gateways.check_vnet_gateway_exists('TestRG-VNG', 'testnetworkgateway')
-    puts "Virtual Network Gateway doesn't exist."
-  end
+  flag = network.virtual_network_gateways.check_vnet_gateway_exists('TestRG-VNG', 'testnetworkgateway')
+  puts "Virtual Network Gateway doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                           Create Virtual Network Gateway                   ######################

--- a/test/integration/zone.rb
+++ b/test/integration/zone.rb
@@ -37,7 +37,7 @@ begin
   ######################                            Check Zone Exists?                              ######################
   ########################################################################################################################
 
-  if !dns.zones.check_zone_exists?('TestRG-ZN', 'test-zone.com')
+  if !dns.zones.check_zone_exists('TestRG-ZN', 'test-zone.com')
     puts "Zone doesn't exist."
   end
 

--- a/test/integration/zone.rb
+++ b/test/integration/zone.rb
@@ -37,9 +37,8 @@ begin
   ######################                            Check Zone Exists?                              ######################
   ########################################################################################################################
 
-  if !dns.zones.check_zone_exists('TestRG-ZN', 'test-zone.com')
-    puts "Zone doesn't exist."
-  end
+  flag = dns.zones.check_zone_exists('TestRG-ZN', 'test-zone.com')
+  puts "Zone doesn't exist." unless flag
 
   ########################################################################################################################
   ######################                                Create Zone                                 ######################

--- a/test/models/application_gateway/test_gateways.rb
+++ b/test/models/application_gateway/test_gateways.rb
@@ -13,7 +13,7 @@ class TestGateways < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_application_gateway_exists?
+      :check_application_gateway_exists
     ]
     methods.each do |method|
       assert_respond_to @gateways, method
@@ -42,14 +42,14 @@ class TestGateways < Minitest::Test
   end
 
   def test_check_application_gateway_exists_true_case
-    @service.stub :check_ag_exists?, true do
-      assert @gateways.check_application_gateway_exists?('fog-test-rg', 'gateway')
+    @service.stub :check_ag_exists, true do
+      assert @gateways.check_application_gateway_exists('fog-test-rg', 'gateway')
     end
   end
 
   def test_check_application_gateway_exists_false_case
-    @service.stub :check_ag_exists?, false do
-      assert !@gateways.check_application_gateway_exists?('fog-test-rg', 'gateway')
+    @service.stub :check_ag_exists, false do
+      assert !@gateways.check_application_gateway_exists('fog-test-rg', 'gateway')
     end
   end
 end

--- a/test/models/compute/test_availability_sets.rb
+++ b/test/models/compute/test_availability_sets.rb
@@ -14,7 +14,7 @@ class TestAvailabilitySets < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_availability_set_exists?
+      :check_availability_set_exists
     ]
     methods.each do |method|
       assert_respond_to @availability_sets, method
@@ -42,14 +42,14 @@ class TestAvailabilitySets < Minitest::Test
   end
 
   def test_check_availability_set_exists_true_case
-    @service.stub :check_availability_set_exists?, true do
-      assert @availability_sets.check_availability_set_exists?('fog-test-rg', 'fog-test-availability-set')
+    @service.stub :check_availability_set_exists, true do
+      assert @availability_sets.check_availability_set_exists('fog-test-rg', 'fog-test-availability-set')
     end
   end
 
   def test_check_availability_set_exists_false_case
-    @service.stub :check_availability_set_exists?, false do
-      assert !@availability_sets.check_availability_set_exists?('fog-test-rg', 'fog-test-availability-set')
+    @service.stub :check_availability_set_exists, false do
+      assert !@availability_sets.check_availability_set_exists('fog-test-rg', 'fog-test-availability-set')
     end
   end
 end

--- a/test/models/compute/test_servers.rb
+++ b/test/models/compute/test_servers.rb
@@ -13,7 +13,7 @@ class TestServers < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_vm_exists?
+      :check_vm_exists
     ]
     methods.each do |method|
       assert_respond_to @servers, method
@@ -42,14 +42,14 @@ class TestServers < Minitest::Test
   end
 
   def test_check_vm_exists_true_case
-    @service.stub :check_vm_exists?, true do
-      assert @servers.check_vm_exists?('fog-test-rg', 'fog-test-server')
+    @service.stub :check_vm_exists, true do
+      assert @servers.check_vm_exists('fog-test-rg', 'fog-test-server')
     end
   end
 
   def test_check_vm_exists_false_case
-    @service.stub :check_vm_exists?, false do
-      assert !@servers.check_vm_exists?('fog-test-rg', 'fog-test-server')
+    @service.stub :check_vm_exists, false do
+      assert !@servers.check_vm_exists('fog-test-rg', 'fog-test-server')
     end
   end
 end

--- a/test/models/compute/test_virtual_machine_extensions.rb
+++ b/test/models/compute/test_virtual_machine_extensions.rb
@@ -12,7 +12,7 @@ class TestVirtualMachineExtensions < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_vm_extension_exists?
+      :check_vm_extension_exists
     ]
     methods.each do |method|
       assert_respond_to @vm_extensions, method
@@ -36,14 +36,14 @@ class TestVirtualMachineExtensions < Minitest::Test
   end
 
   def test_check_vm_extension_exists_true_case
-    @service.stub :check_vm_extension_exists?, true do
-      assert @vm_extensions.check_vm_extension_exists?('fog-test-rg', 'fog-test-server', 'fog-test-extension')
+    @service.stub :check_vm_extension_exists, true do
+      assert @vm_extensions.check_vm_extension_exists('fog-test-rg', 'fog-test-server', 'fog-test-extension')
     end
   end
 
   def test_check_vm_extension_exists_false_case
-    @service.stub :check_vm_extension_exists?, false do
-      assert !@vm_extensions.check_vm_extension_exists?('fog-test-rg', 'fog-test-server', 'fog-test-extension')
+    @service.stub :check_vm_extension_exists, false do
+      assert !@vm_extensions.check_vm_extension_exists('fog-test-rg', 'fog-test-server', 'fog-test-extension')
     end
   end
 end

--- a/test/models/dns/test_record_sets.rb
+++ b/test/models/dns/test_record_sets.rb
@@ -13,7 +13,7 @@ class TestRecordSets < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_record_set_exists?
+      :check_record_set_exists
     ]
     methods.each do |method|
       assert_respond_to @record_sets, method
@@ -53,14 +53,14 @@ class TestRecordSets < Minitest::Test
   end
 
   def test_check_record_set_exists_true_case
-    @service.stub :check_record_set_exists?, true do
-      assert @record_sets.check_record_set_exists?('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', 'A')
+    @service.stub :check_record_set_exists, true do
+      assert @record_sets.check_record_set_exists('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', 'A')
     end
   end
 
   def test_check_record_set_exists_false_case
-    @service.stub :check_record_set_exists?, false do
-      assert !@record_sets.check_record_set_exists?('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', 'A')
+    @service.stub :check_record_set_exists, false do
+      assert !@record_sets.check_record_set_exists('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', 'A')
     end
   end
 end

--- a/test/models/dns/test_zones.rb
+++ b/test/models/dns/test_zones.rb
@@ -13,7 +13,7 @@ class TestZones < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_zone_exists?
+      :check_zone_exists
     ]
     methods.each do |method|
       assert_respond_to @zones, method
@@ -38,14 +38,14 @@ class TestZones < Minitest::Test
   end
 
   def test_check_zone_exists_true_response
-    @service.stub :check_zone_exists?, true do
-      assert @zones.check_zone_exists?('fog-test-rg', 'fog-test-zone.com')
+    @service.stub :check_zone_exists, true do
+      assert @zones.check_zone_exists('fog-test-rg', 'fog-test-zone.com')
     end
   end
 
   def test_check_zone_exists_false_response
-    @service.stub :check_zone_exists?, true do
-      assert @zones.check_zone_exists?('fog-test-rg', 'fog-test-zone.com')
+    @service.stub :check_zone_exists, true do
+      assert @zones.check_zone_exists('fog-test-rg', 'fog-test-zone.com')
     end
   end
 end

--- a/test/models/key_vault/test_vaults.rb
+++ b/test/models/key_vault/test_vaults.rb
@@ -13,7 +13,7 @@ class TestVaults < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_vault_exists?
+      :check_vault_exists
     ]
     methods.each do |method|
       assert_respond_to @vaults, method
@@ -42,14 +42,14 @@ class TestVaults < Minitest::Test
   end
 
   def test_check_vault_exists_true_response
-    @service.stub :check_vault_exists?, true do
-      assert @vaults.check_vault_exists?('fog-test-rg', 'fog-test-kv')
+    @service.stub :check_vault_exists, true do
+      assert @vaults.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 
   def test_check_vault_exists_false_response
-    @service.stub :check_vault_exists?, false do
-      assert !@vaults.check_vault_exists?('fog-test-rg', 'fog-test-kv')
+    @service.stub :check_vault_exists, false do
+      assert !@vaults.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 end

--- a/test/models/network/test_express_route_circuit_authorizations.rb
+++ b/test/models/network/test_express_route_circuit_authorizations.rb
@@ -12,7 +12,7 @@ class TestExpressRouteCircuitAuthorizations < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_express_route_cir_auth_exists?
+      :check_express_route_cir_auth_exists
     ]
     methods.each do |method|
       assert_respond_to @circuit_authorizations, method
@@ -43,14 +43,14 @@ class TestExpressRouteCircuitAuthorizations < Minitest::Test
   end
 
   def test_check_express_route_cir_auth_exists_true_response
-    @service.stub :check_express_route_cir_auth_exists?, true do
-      assert @circuit_authorizations.check_express_route_cir_auth_exists?('HaiderRG', 'testCircuit', 'auth-name')
+    @service.stub :check_express_route_cir_auth_exists, true do
+      assert @circuit_authorizations.check_express_route_cir_auth_exists('HaiderRG', 'testCircuit', 'auth-name')
     end
   end
 
   def test_check_express_route_cir_auth_exists_false_response
-    @service.stub :check_express_route_cir_auth_exists?, false do
-      assert !@circuit_authorizations.check_express_route_cir_auth_exists?('HaiderRG', 'testCircuit', 'auth-name')
+    @service.stub :check_express_route_cir_auth_exists, false do
+      assert !@circuit_authorizations.check_express_route_cir_auth_exists('HaiderRG', 'testCircuit', 'auth-name')
     end
   end
 end

--- a/test/models/network/test_express_route_circuits.rb
+++ b/test/models/network/test_express_route_circuits.rb
@@ -12,7 +12,7 @@ class TestExpressRouteCircuits < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_express_route_circuit_exists?
+      :check_express_route_circuit_exists
     ]
     methods.each do |method|
       assert_respond_to @circuits, method
@@ -42,14 +42,14 @@ class TestExpressRouteCircuits < Minitest::Test
   end
 
   def test_check_express_route_circuit_exists_true_response
-    @service.stub :check_express_route_circuit_exists?, true do
-      assert @circuits.check_express_route_circuit_exists?('HaiderRG', 'testCircuit')
+    @service.stub :check_express_route_circuit_exists, true do
+      assert @circuits.check_express_route_circuit_exists('HaiderRG', 'testCircuit')
     end
   end
 
   def test_check_express_route_circuit_exists_false_response
-    @service.stub :check_express_route_circuit_exists?, false do
-      assert !@circuits.check_express_route_circuit_exists?('HaiderRG', 'testCircuit')
+    @service.stub :check_express_route_circuit_exists, false do
+      assert !@circuits.check_express_route_circuit_exists('HaiderRG', 'testCircuit')
     end
   end
 end

--- a/test/models/network/test_load_balancers.rb
+++ b/test/models/network/test_load_balancers.rb
@@ -13,7 +13,7 @@ class TestLoadBalancers < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_load_balancer_exists?
+      :check_load_balancer_exists
     ]
     methods.each do |method|
       assert_respond_to @load_balancers, method
@@ -42,14 +42,14 @@ class TestLoadBalancers < Minitest::Test
   end
 
   def test_check_load_balancer_exists_true_response
-    @service.stub :check_load_balancer_exists?, true do
-      assert @load_balancers.check_load_balancer_exists?('fog-test-rg', 'mylb1')
+    @service.stub :check_load_balancer_exists, true do
+      assert @load_balancers.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 
   def test_check_load_balancer_exists_false_response
-    @service.stub :check_load_balancer_exists?, false do
-      assert !@load_balancers.check_load_balancer_exists?('fog-test-rg', 'mylb1')
+    @service.stub :check_load_balancer_exists, false do
+      assert !@load_balancers.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 end

--- a/test/models/network/test_local_network_gateways.rb
+++ b/test/models/network/test_local_network_gateways.rb
@@ -13,7 +13,7 @@ class TestLocalNetworkGateways < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_local_net_gateway_exists?
+      :check_local_net_gateway_exists
     ]
     methods.each do |method|
       assert_respond_to @local_network_gateways, method
@@ -42,14 +42,14 @@ class TestLocalNetworkGateways < Minitest::Test
   end
 
   def test_check_local_net_gateway_exists_true_response
-    @service.stub :check_local_net_gateway_exists?, true do
-      assert @local_network_gateways.check_local_net_gateway_exists?('fog-rg', 'mylocalgateway1')
+    @service.stub :check_local_net_gateway_exists, true do
+      assert @local_network_gateways.check_local_net_gateway_exists('fog-rg', 'mylocalgateway1')
     end
   end
 
   def test_check_local_net_gateway_exists_false_response
-    @service.stub :check_local_net_gateway_exists?, false do
-      assert !@local_network_gateways.check_local_net_gateway_exists?('fog-rg', 'mylocalgateway1')
+    @service.stub :check_local_net_gateway_exists, false do
+      assert !@local_network_gateways.check_local_net_gateway_exists('fog-rg', 'mylocalgateway1')
     end
   end
 end

--- a/test/models/network/test_network_interfaces.rb
+++ b/test/models/network/test_network_interfaces.rb
@@ -12,7 +12,7 @@ class TestNetworkInterfaces < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_network_interface_exists?
+      :check_network_interface_exists
     ]
     methods.each do |method|
       assert_respond_to @network_interfaces, method
@@ -42,14 +42,14 @@ class TestNetworkInterfaces < Minitest::Test
   end
 
   def test_check_network_interface_exists_true_response
-    @service.stub :check_network_interface_exists?, true do
-      assert @network_interfaces.check_network_interface_exists?('fog-test-rg', 'fog-test-network-interface')
+    @service.stub :check_network_interface_exists, true do
+      assert @network_interfaces.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 
   def test_check_network_interface_exists_false_response
-    @service.stub :check_network_interface_exists?, false do
-      assert !@network_interfaces.check_network_interface_exists?('fog-test-rg', 'fog-test-network-interface')
+    @service.stub :check_network_interface_exists, false do
+      assert !@network_interfaces.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 end

--- a/test/models/network/test_network_security_groups.rb
+++ b/test/models/network/test_network_security_groups.rb
@@ -13,7 +13,7 @@ class TestNetworkSecurityGroups < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_net_sec_group_exists?
+      :check_net_sec_group_exists
     ]
     methods.each do |method|
       assert_respond_to @network_security_groups, method
@@ -41,14 +41,14 @@ class TestNetworkSecurityGroups < Minitest::Test
   end
 
   def test_check_net_sec_group_exists_true_response
-    @service.stub :check_net_sec_group_exists?, true do
-      assert @network_security_groups.check_net_sec_group_exists?('fog-test-rg', 'fog-test-nsg')
+    @service.stub :check_net_sec_group_exists, true do
+      assert @network_security_groups.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg')
     end
   end
 
   def test_check_net_sec_group_exists_false_response
-    @service.stub :check_net_sec_group_exists?, false do
-      assert !@network_security_groups.check_net_sec_group_exists?('fog-test-rg', 'fog-test-nsg')
+    @service.stub :check_net_sec_group_exists, false do
+      assert !@network_security_groups.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg')
     end
   end
 end

--- a/test/models/network/test_network_security_rules.rb
+++ b/test/models/network/test_network_security_rules.rb
@@ -13,7 +13,7 @@ class TestNetworkSecurityRules < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_net_sec_rule_exists?
+      :check_net_sec_rule_exists
     ]
     methods.each do |method|
       assert_respond_to @network_security_rules, method
@@ -42,14 +42,14 @@ class TestNetworkSecurityRules < Minitest::Test
   end
 
   def test_check_net_sec_rule_exists_true_response
-    @service.stub :check_net_sec_rule_exists?, true do
-      assert @network_security_rules.check_net_sec_rule_exists?('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
+    @service.stub :check_net_sec_rule_exists, true do
+      assert @network_security_rules.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 
   def test_check_net_sec_rule_exists_false_response
-    @service.stub :check_net_sec_rule_exists?, false do
-      assert !@network_security_rules.check_net_sec_rule_exists?('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
+    @service.stub :check_net_sec_rule_exists, false do
+      assert !@network_security_rules.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 end

--- a/test/models/network/test_public_ips.rb
+++ b/test/models/network/test_public_ips.rb
@@ -13,7 +13,7 @@ class TestPublicIps < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_public_ip_exists?
+      :check_public_ip_exists
     ]
     methods.each do |method|
       assert_respond_to @public_ips, method
@@ -42,14 +42,14 @@ class TestPublicIps < Minitest::Test
   end
 
   def test_check_public_ip_exists_method_success
-    @service.stub :check_public_ip_exists?, true do
-      assert @public_ips.check_public_ip_exists?('fog-test-rg', 'fog-test-public-ip')
+    @service.stub :check_public_ip_exists, true do
+      assert @public_ips.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 
   def test_check_if_exists_method_failure
-    @service.stub :check_public_ip_exists?, false do
-      assert !@public_ips.check_public_ip_exists?('fog-test-rg', 'fog-test-public-ip')
+    @service.stub :check_public_ip_exists, false do
+      assert !@public_ips.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 end

--- a/test/models/network/test_subnets.rb
+++ b/test/models/network/test_subnets.rb
@@ -12,7 +12,7 @@ class TestSubnets < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_subnet_exists?
+      :check_subnet_exists
     ]
     methods.each do |method|
       assert_respond_to @subnets, method
@@ -43,14 +43,14 @@ class TestSubnets < Minitest::Test
   end
 
   def test_check_subnet_exists_true_response
-    @service.stub :check_subnet_exists?, true do
-      assert @subnets.check_subnet_exists?('fog-test-rg', 'fog-test-vnet', 'fog-test-subnet')
+    @service.stub :check_subnet_exists, true do
+      assert @subnets.check_subnet_exists('fog-test-rg', 'fog-test-vnet', 'fog-test-subnet')
     end
   end
 
   def test_check_subnet_exists_false_response
-    @service.stub :check_subnet_exists?, false do
-      assert !@subnets.check_subnet_exists?('fog-test-rg', 'fog-test-vnet', 'fog-test-subnet')
+    @service.stub :check_subnet_exists, false do
+      assert !@subnets.check_subnet_exists('fog-test-rg', 'fog-test-vnet', 'fog-test-subnet')
     end
   end
 end

--- a/test/models/network/test_virtual_network_gateway_connections.rb
+++ b/test/models/network/test_virtual_network_gateway_connections.rb
@@ -13,7 +13,7 @@ class TestVirtualNetworkGatewayConnections < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_vnet_gateway_connection_exists?
+      :check_vnet_gateway_connection_exists
     ]
     methods.each do |method|
       assert_respond_to @gateway_connections, method
@@ -42,14 +42,14 @@ class TestVirtualNetworkGatewayConnections < Minitest::Test
   end
 
   def test_check_vnet_gateway_connection_exists_true_response
-    @service.stub :check_vnet_gateway_connection_exists?, true do
-      assert @gateway_connections.check_vnet_gateway_connection_exists?('fog-rg', 'cn1')
+    @service.stub :check_vnet_gateway_connection_exists, true do
+      assert @gateway_connections.check_vnet_gateway_connection_exists('fog-rg', 'cn1')
     end
   end
 
   def test_check_vnet_gateway_connection_exists_false_response
-    @service.stub :check_vnet_gateway_connection_exists?, false do
-      assert !@gateway_connections.check_vnet_gateway_connection_exists?('fog-rg', 'cn1')
+    @service.stub :check_vnet_gateway_connection_exists, false do
+      assert !@gateway_connections.check_vnet_gateway_connection_exists('fog-rg', 'cn1')
     end
   end
 end

--- a/test/models/network/test_virtual_network_gateways.rb
+++ b/test/models/network/test_virtual_network_gateways.rb
@@ -12,7 +12,7 @@ class TestVirtualNetworkGateways < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_vnet_gateway_exists?
+      :check_vnet_gateway_exists
     ]
     methods.each do |method|
       assert_respond_to @network_gateways, method
@@ -42,14 +42,14 @@ class TestVirtualNetworkGateways < Minitest::Test
   end
 
   def test_check_vnet_gateway_exists_true_response
-    @service.stub :check_vnet_gateway_exists?, true do
-      assert @network_gateways.check_vnet_gateway_exists?('fog-rg', 'myvirtualgateway1')
+    @service.stub :check_vnet_gateway_exists, true do
+      assert @network_gateways.check_vnet_gateway_exists('fog-rg', 'myvirtualgateway1')
     end
   end
 
   def test_check_vnet_gateway_exists_false_response
-    @service.stub :check_vnet_gateway_exists?, false do
-      assert !@network_gateways.check_vnet_gateway_exists?('fog-rg', 'myvirtualgateway1')
+    @service.stub :check_vnet_gateway_exists, false do
+      assert !@network_gateways.check_vnet_gateway_exists('fog-rg', 'myvirtualgateway1')
     end
   end
 end

--- a/test/models/network/test_virtual_networks.rb
+++ b/test/models/network/test_virtual_networks.rb
@@ -12,7 +12,7 @@ class TestVirtualNetworks < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_virtual_network_exists?
+      :check_virtual_network_exists
     ]
     methods.each do |method|
       assert_respond_to @virtual_networks, method
@@ -54,14 +54,14 @@ class TestVirtualNetworks < Minitest::Test
   end
 
   def test_check_virtual_network_exists_method_success
-    @service.stub :check_virtual_network_exists?, true do
-      assert @virtual_networks.check_virtual_network_exists?('fog-rg', 'fog-test-virtual-network')
+    @service.stub :check_virtual_network_exists, true do
+      assert @virtual_networks.check_virtual_network_exists('fog-rg', 'fog-test-virtual-network')
     end
   end
 
   def test_check_virtual_network_exists_method_failure
-    @service.stub :check_virtual_network_exists?, false do
-      assert !@virtual_networks.check_virtual_network_exists?('fog-rg', 'fog-test-virtual-network')
+    @service.stub :check_virtual_network_exists, false do
+      assert !@virtual_networks.check_virtual_network_exists('fog-rg', 'fog-test-virtual-network')
     end
   end
 end

--- a/test/models/resources/test_deployments.rb
+++ b/test/models/resources/test_deployments.rb
@@ -13,7 +13,7 @@ class TestDeployments < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_deployment_exists?
+      :check_deployment_exists
     ]
     methods.each do |method|
       assert_respond_to @deployments, method
@@ -38,14 +38,14 @@ class TestDeployments < Minitest::Test
   end
 
   def test_check_deployment_exists_true_response
-    @service.stub :check_deployment_exists?, true do
-      assert @deployments.check_deployment_exists?('fog-test-rg', 'fog-test-deployment')
+    @service.stub :check_deployment_exists, true do
+      assert @deployments.check_deployment_exists('fog-test-rg', 'fog-test-deployment')
     end
   end
 
   def test_check_deployment_exists_false_response
-    @service.stub :check_deployment_exists?, false do
-      assert !@deployments.check_deployment_exists?('fog-test-rg', 'fog-test-deployment')
+    @service.stub :check_deployment_exists, false do
+      assert !@deployments.check_deployment_exists('fog-test-rg', 'fog-test-deployment')
     end
   end
 end

--- a/test/models/resources/test_resource_groups.rb
+++ b/test/models/resources/test_resource_groups.rb
@@ -13,7 +13,7 @@ class TestResourceGroups < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_resource_group_exists?
+      :check_resource_group_exists
     ]
     methods.each do |method|
       assert_respond_to @resource_groups, method
@@ -38,14 +38,14 @@ class TestResourceGroups < Minitest::Test
   end
 
   def test_check_resource_group_exists_true_response
-    @service.stub :check_resource_group_exists?, true do
-      assert @resource_groups.check_resource_group_exists?('fog-test-rg')
+    @service.stub :check_resource_group_exists, true do
+      assert @resource_groups.check_resource_group_exists('fog-test-rg')
     end
   end
 
   def test_check_resource_group_exists_false_response
-    @service.stub :check_resource_group_exists?, false do
-      assert !@resource_groups.check_resource_group_exists?('fog-test-rg')
+    @service.stub :check_resource_group_exists, false do
+      assert !@resource_groups.check_resource_group_exists('fog-test-rg')
     end
   end
 end

--- a/test/models/resources/test_resources.rb
+++ b/test/models/resources/test_resources.rb
@@ -14,7 +14,7 @@ class TestResources < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_azure_resource_exists?
+      :check_azure_resource_exists
     ]
     methods.each do |method|
       assert_respond_to @resources, method
@@ -39,14 +39,14 @@ class TestResources < Minitest::Test
   end
 
   def test_check_azure_resource_exists_true_response
-    @service.stub :check_azure_resource_exists?, true do
-      assert @resources.check_azure_resource_exists?(@resource_id, '2016-09-01')
+    @service.stub :check_azure_resource_exists, true do
+      assert @resources.check_azure_resource_exists(@resource_id, '2016-09-01')
     end
   end
 
   def test_check_azure_resource_exists_false_response
-    @service.stub :check_azure_resource_exists?, false do
-      assert !@resources.check_azure_resource_exists?(@resource_id, '2016-09-01')
+    @service.stub :check_azure_resource_exists, false do
+      assert !@resources.check_azure_resource_exists(@resource_id, '2016-09-01')
     end
   end
 end

--- a/test/models/storage/test_directories.rb
+++ b/test/models/storage/test_directories.rb
@@ -15,7 +15,7 @@ class TestDirectories < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_container_exists?
+      :check_container_exists
     ]
     methods.each do |method|
       assert_respond_to @directories, method
@@ -61,14 +61,14 @@ class TestDirectories < Minitest::Test
   end
 
   def test_check_container_exists_true_response
-    @service.stub :check_container_exists?, true do
-      assert @directories.check_container_exists?('test_container')
+    @service.stub :check_container_exists, true do
+      assert @directories.check_container_exists('test_container')
     end
   end
 
   def test_check_container_exists_false_response
-    @service.stub :check_container_exists?, false do
-      assert !@directories.check_container_exists?('test_container')
+    @service.stub :check_container_exists, false do
+      assert !@directories.check_container_exists('test_container')
     end
   end
 end

--- a/test/models/storage/test_storage_accounts.rb
+++ b/test/models/storage/test_storage_accounts.rb
@@ -13,7 +13,7 @@ class TestStorageAccounts < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_storage_account_exists?
+      :check_storage_account_exists
     ]
     methods.each do |method|
       assert_respond_to @storage_accounts, method
@@ -65,14 +65,14 @@ class TestStorageAccounts < Minitest::Test
   end
 
   def test_check_storage_account_exists_true_response
-    @service.stub :check_storage_account_exists?, true do
-      assert @storage_accounts.check_storage_account_exists?('fog-test-rg', 'fog-test-storage-account')
+    @service.stub :check_storage_account_exists, true do
+      assert @storage_accounts.check_storage_account_exists('fog-test-rg', 'fog-test-storage-account')
     end
   end
 
   def test_check_storage_account_exists_false_response
-    @service.stub :check_storage_account_exists?, false do
-      assert !@storage_accounts.check_storage_account_exists?('fog-test-rg', 'fog-test-storage-account')
+    @service.stub :check_storage_account_exists, false do
+      assert !@storage_accounts.check_storage_account_exists('fog-test-rg', 'fog-test-storage-account')
     end
   end
 end

--- a/test/models/traffic_manager/test_traffic_manager_end_points.rb
+++ b/test/models/traffic_manager/test_traffic_manager_end_points.rb
@@ -14,7 +14,7 @@ class TestTrafficManagerEndPoints < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_traffic_manager_endpoint_exists?
+      :check_traffic_manager_endpoint_exists
     ]
     methods.each do |method|
       assert_respond_to @traffic_manager_end_points, method
@@ -43,14 +43,14 @@ class TestTrafficManagerEndPoints < Minitest::Test
   end
 
   def test_check_traffic_manager_endpoint_exists_true_response
-    @service.stub :check_traffic_manager_endpoint_exists?, true do
-      assert @traffic_manager_end_points.check_traffic_manager_endpoint_exists?('resource-group-name', 'profile-name', 'endpoint-name1', 'endpoint-type')
+    @service.stub :check_traffic_manager_endpoint_exists, true do
+      assert @traffic_manager_end_points.check_traffic_manager_endpoint_exists('resource-group-name', 'profile-name', 'endpoint-name1', 'endpoint-type')
     end
   end
 
   def test_check_traffic_manager_endpoint_exists_false_response
-    @service.stub :check_traffic_manager_endpoint_exists?, false do
-      assert !@traffic_manager_end_points.check_traffic_manager_endpoint_exists?('resource-group-name', 'profile-name', 'endpoint-name1', 'endpoint-type')
+    @service.stub :check_traffic_manager_endpoint_exists, false do
+      assert !@traffic_manager_end_points.check_traffic_manager_endpoint_exists('resource-group-name', 'profile-name', 'endpoint-name1', 'endpoint-type')
     end
   end
 end

--- a/test/models/traffic_manager/test_traffic_manager_profiles.rb
+++ b/test/models/traffic_manager/test_traffic_manager_profiles.rb
@@ -14,7 +14,7 @@ class TestTrafficManagerProfiles < Minitest::Test
     methods = [
       :all,
       :get,
-      :check_traffic_manager_profile_exists?
+      :check_traffic_manager_profile_exists
     ]
     methods.each do |method|
       assert_respond_to @traffic_manager_profiles, method
@@ -42,14 +42,14 @@ class TestTrafficManagerProfiles < Minitest::Test
   end
 
   def test_check_traffic_manager_profile_exists_true_response
-    @service.stub :check_traffic_manager_profile_exists?, true do
-      assert @traffic_manager_profiles.check_traffic_manager_profile_exists?('resource-group-name', 'fog-test-profile-name')
+    @service.stub :check_traffic_manager_profile_exists, true do
+      assert @traffic_manager_profiles.check_traffic_manager_profile_exists('resource-group-name', 'fog-test-profile-name')
     end
   end
 
   def test_check_traffic_manager_profile_exists_false_response
-    @service.stub :check_traffic_manager_profile_exists?, false do
-      assert !@traffic_manager_profiles.check_traffic_manager_profile_exists?('resource-group-name', 'fog-test-profile-name')
+    @service.stub :check_traffic_manager_profile_exists, false do
+      assert !@traffic_manager_profiles.check_traffic_manager_profile_exists('resource-group-name', 'fog-test-profile-name')
     end
   end
 end

--- a/test/requests/application_gateway/test_check_ag_exists.rb
+++ b/test/requests/application_gateway/test_check_ag_exists.rb
@@ -11,21 +11,21 @@ class TestCheckAGExists < Minitest::Test
   def test_check_ag_exists_success
     mocked_response = ApiStub::Requests::ApplicationGateway::Gateway.create_application_gateway_response(@gateway_client)
     @gateways.stub :get, mocked_response do
-      assert @service.check_ag_exists?('fog-test-rg', 'fogRM-rg')
+      assert @service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end
   end
 
   def test_check_ag_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @gateways.stub :get, response do
-      assert !@service.check_ag_exists?('fog-test-rg', 'fogRM-rg')
+      assert !@service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end
   end
 
   def test_check_ag_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_ag_exists?('fog-test-rg', 'fogRM-rg') }
+      assert_raises(RuntimeError) { @service.check_ag_exists('fog-test-rg', 'fogRM-rg') }
     end
   end
 end

--- a/test/requests/compute/test_check_availability_set_exists.rb
+++ b/test/requests/compute/test_check_availability_set_exists.rb
@@ -11,21 +11,21 @@ class TestCheckAvailabilitySetExists < Minitest::Test
   def test_check_availability_set_exists_success
     mocked_response = ApiStub::Requests::Compute::AvailabilitySet.get_availability_set_response(@client)
     @availability_sets.stub :get, mocked_response do
-      assert @service.check_availability_set_exists?('myrg1', 'myavset1')
+      assert @service.check_availability_set_exists('myrg1', 'myavset1')
     end
   end
 
   def test_check_availability_set_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @availability_sets.stub :get, response do
-      assert !@service.check_availability_set_exists?('myrg1', 'myavset1')
+      assert !@service.check_availability_set_exists('myrg1', 'myavset1')
     end
   end
 
   def test_check_availability_set_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @availability_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_availability_set_exists?('myrg1', 'myavset1') }
+      assert_raises(RuntimeError) { @service.check_availability_set_exists('myrg1', 'myavset1') }
     end
   end
 end

--- a/test/requests/compute/test_check_vm_exists.rb
+++ b/test/requests/compute/test_check_vm_exists.rb
@@ -11,21 +11,21 @@ class TestCheckVirtualMachineExists < Minitest::Test
   def test_check_vm_exists_success
     response = ApiStub::Requests::Compute::VirtualMachine.create_virtual_machine_response(@compute_client)
     @virtual_machines.stub :get, response do
-      assert @service.check_vm_exists?('fog-test-rg', 'fog-test-server')
+      assert @service.check_vm_exists('fog-test-rg', 'fog-test-server')
     end
   end
 
   def test_check_vm_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @virtual_machines.stub :get, response do
-      assert !@service.check_vm_exists?('fog-test-rg', 'fog-test-server')
+      assert !@service.check_vm_exists('fog-test-rg', 'fog-test-server')
     end
   end
 
   def test_check_vm_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @virtual_machines.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_exists?('fog-test-rg', 'fog-test-server') }
+      assert_raises(RuntimeError) { @service.check_vm_exists('fog-test-rg', 'fog-test-server') }
     end
   end
 end

--- a/test/requests/compute/test_check_vm_extension_exists.rb
+++ b/test/requests/compute/test_check_vm_extension_exists.rb
@@ -11,21 +11,21 @@ class TestCheckVMExtensionExists < Minitest::Test
   def test_check_vm_extension_exists_success
     response = ApiStub::Requests::Compute::VirtualMachineExtension.create_vm_extension_response(@compute_client)
     @vm_extension.stub :get, response do
-      assert @service.check_vm_extension_exists?('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
+      assert @service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
     end
   end
 
   def test_check_vm_extension_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @vm_extension.stub :get, response do
-      assert !@service.check_vm_extension_exists?('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
+      assert !@service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
     end
   end
 
   def test_check_vm_extension_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @vm_extension.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_extension_exists?('fog-test-rg', 'fog-test-vm', 'fog-test-extension') }
+      assert_raises(RuntimeError) { @service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension') }
     end
   end
 end

--- a/test/requests/dns/test_check_record_set_exists.rb
+++ b/test/requests/dns/test_check_record_set_exists.rb
@@ -11,21 +11,21 @@ class TestCheckRecordSetExists < Minitest::Test
   def test_check_record_set_exists_success
     mocked_response = ApiStub::Requests::DNS::RecordSet.record_set_response_for_cname_type(@dns_client)
     @record_sets.stub :get, mocked_response do
-      assert @service.check_record_set_exists?('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
+      assert @service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
     end
   end
 
   def test_check_record_set_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'code' => 'NotFound' ) }
     @record_sets.stub :get, response do
-      assert !@service.check_record_set_exists?('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
+      assert !@service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
     end
   end
 
   def test_check_record_set_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @record_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_record_set_exists?('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
+      assert_raises(RuntimeError) { @service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
     end
   end
 end

--- a/test/requests/dns/test_check_zone_exists.rb
+++ b/test/requests/dns/test_check_zone_exists.rb
@@ -11,7 +11,7 @@ class TestCheckZoneExists < Minitest::Test
   def test_check_zone_exists_success
     mocked_response = ApiStub::Requests::DNS::Zone.zone_response(@dns_client)
     @zones.stub :get, mocked_response do
-      assert_equal @service.check_zone_exists?('fog-test-rg', 'zone_name'), true
+      assert_equal @service.check_zone_exists('fog-test-rg', 'zone_name'), true
     end
   end
 
@@ -19,7 +19,7 @@ class TestCheckZoneExists < Minitest::Test
     response = ApiStub::Requests::DNS::RecordSet.list_record_sets_response(@dns_client)
     @zones.stub :get, response do
       assert_raises ArgumentError do
-        @service.check_zone_exists?('fog-test-rg')
+        @service.check_zone_exists('fog-test-rg')
       end
     end
   end
@@ -28,7 +28,7 @@ class TestCheckZoneExists < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @zones.stub :get, response do
       assert_raises RuntimeError do
-        @service.check_zone_exists?('fog-test-rg', 'zone_name')
+        @service.check_zone_exists('fog-test-rg', 'zone_name')
       end
     end
   end

--- a/test/requests/key_vault/test_check_vault_exists.rb
+++ b/test/requests/key_vault/test_check_vault_exists.rb
@@ -11,21 +11,21 @@ class TestCheckVaultExists < Minitest::Test
   def test_check_vault_exists_success
     response = ApiStub::Requests::KeyVault::Vault.create_vault_response(@key_vault_client)
     @vaults.stub :get, response do
-      assert @service.check_vault_exists?('fog-test-rg', 'fog-test-kv')
+      assert @service.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 
   def test_check_vault_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @vaults.stub :get, response do
-      assert !@service.check_vault_exists?('fog-test-rg', 'fog-test-kv')
+      assert !@service.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 
   def test_check_vault_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @vaults.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vault_exists?('fog-test-rg', 'fog-test-kv') }
+      assert_raises(RuntimeError) { @service.check_vault_exists('fog-test-rg', 'fog-test-kv') }
     end
   end
 end

--- a/test/requests/network/test_check_express_route_cir_auth_exists.rb
+++ b/test/requests/network/test_check_express_route_cir_auth_exists.rb
@@ -11,21 +11,21 @@ class TestCheckExpressRouteCirAuthExists < Minitest::Test
   def test_check_express_route_cir_auth_exists_success
     mocked_response = ApiStub::Requests::Network::ExpressRouteCircuitAuthorization.create_express_route_circuit_authorization_response(@network_client)
     @circuit_authorization.stub :get, mocked_response do
-      assert @service.check_express_route_cir_auth_exists?('Fog-rg', 'testCircuit', 'auth-name')
+      assert @service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name')
     end
   end
 
   def test_check_express_route_cir_auth_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @circuit_authorization.stub :get, response do
-      assert !@service.check_express_route_cir_auth_exists?('Fog-rg', 'testCircuit', 'auth-name')
+      assert !@service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name')
     end
   end
 
   def test_check_express_route_cir_auth_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @circuit_authorization.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_cir_auth_exists?('Fog-rg', 'testCircuit', 'auth-name') }
+      assert_raises(RuntimeError) { @service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name') }
     end
   end
 end

--- a/test/requests/network/test_check_express_route_circuit_exists.rb
+++ b/test/requests/network/test_check_express_route_circuit_exists.rb
@@ -11,21 +11,21 @@ class TestCheckExpressRouteCircuitExists < Minitest::Test
   def test_check_express_route_circuit_exists_success
     mocked_response = ApiStub::Requests::Network::ExpressRouteCircuit.create_express_route_circuit_response(@network_client)
     @circuit.stub :get, mocked_response do
-      assert @service.check_express_route_circuit_exists?('fog-test-rg', 'testCircuit')
+      assert @service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit')
     end
   end
 
   def test_check_express_route_circuit_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @circuit.stub :get, response do
-      assert !@service.check_express_route_circuit_exists?('fog-test-rg', 'testCircuit')
+      assert !@service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit')
     end
   end
 
   def test_check_express_route_circuit_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @circuit.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_circuit_exists?('fog-test-rg', 'testCircuit') }
+      assert_raises(RuntimeError) { @service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_check_load_balancer_exists.rb
+++ b/test/requests/network/test_check_load_balancer_exists.rb
@@ -11,21 +11,21 @@ class TestCheckLoadBalancerExists < Minitest::Test
   def test_check_load_balancer_exists_success
     mocked_response = ApiStub::Requests::Network::LoadBalancer.create_load_balancer_response(@network_client)
     @load_balancers.stub :get, mocked_response do
-      assert @service.check_load_balancer_exists?('fog-test-rg', 'mylb1')
+      assert @service.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 
   def test_check_load_balancer_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @load_balancers.stub :get, response do
-      assert !@service.check_load_balancer_exists?('fog-test-rg', 'mylb1')
+      assert !@service.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 
   def test_check_load_balancer_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @load_balancers.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_load_balancer_exists?('fog-test-rg', 'mylb1') }
+      assert_raises(RuntimeError) { @service.check_load_balancer_exists('fog-test-rg', 'mylb1') }
     end
   end
 end

--- a/test/requests/network/test_check_local_net_gateway_exists.rb
+++ b/test/requests/network/test_check_local_net_gateway_exists.rb
@@ -11,21 +11,21 @@ class TestCheckLocalNetworkGatewayExists < Minitest::Test
   def test_check_local_net_gateway_exists_success
     mocked_response = ApiStub::Requests::Network::LocalNetworkGateway.create_local_network_gateway_response(@network_client)
     @local_network_gateways.stub :get, mocked_response do
-      assert @service.check_local_net_gateway_exists?('fog-test-rg', 'fog-test-local-network-gateway')
+      assert @service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway')
     end
   end
 
   def test_check_virtual_network_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @local_network_gateways.stub :get, response do
-      assert !@service.check_local_net_gateway_exists?('fog-test-rg', 'fog-test-local-network-gateway')
+      assert !@service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway')
     end
   end
 
   def test_check_fvirtual_network_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @local_network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_local_net_gateway_exists?('fog-test-rg', 'fog-test-local-network-gateway') }
+      assert_raises(RuntimeError) { @service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_group_exists.rb
+++ b/test/requests/network/test_check_net_sec_group_exists.rb
@@ -11,21 +11,21 @@ class TestCheckNetworkSecurityGroupExists < Minitest::Test
   def test_check_net_sec_group_exists_success
     mocked_response = ApiStub::Requests::Network::NetworkSecurityGroup.create_network_security_group_response(@client)
     @network_security_groups.stub :get, mocked_response do
-      assert_equal @service.check_net_sec_group_exists?('fog-test-rg', 'fog-test-nsg'), true
+      assert_equal @service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg'), true
     end
   end
 
   def test_check_net_sec_group_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_security_groups.stub :get, response do
-      assert !@service.check_net_sec_group_exists?('fog-test-rg', 'fog-test-nsg')
+      assert !@service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg')
     end
   end
 
   def test_check_net_sec_group_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_security_groups.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_group_exists?('fog-test-rg', 'fog-test-nsg') }
+      assert_raises(RuntimeError) { @service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg') }
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_rule_exists.rb
+++ b/test/requests/network/test_check_net_sec_rule_exists.rb
@@ -11,21 +11,21 @@ class TestCheckNetworkSecurityRuleExists < Minitest::Test
   def test_check_net_sec_rule_exists_success
     mocked_response = ApiStub::Requests::Network::NetworkSecurityRule.create_network_security_rule_response(@client)
     @network_security_rules.stub :get, mocked_response do
-      assert @service.check_net_sec_rule_exists?('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
+      assert @service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 
   def test_check_net_sec_rule_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_security_rules.stub :get, response do
-      assert !@service.check_net_sec_rule_exists?('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
+      assert !@service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 
   def test_check_net_sec_rule_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_security_rules.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_rule_exists?('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr') }
+      assert_raises(RuntimeError) { @service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr') }
     end
   end
 end

--- a/test/requests/network/test_check_network_interface_exists.rb
+++ b/test/requests/network/test_check_network_interface_exists.rb
@@ -11,21 +11,21 @@ class TestCheckNetworkInterfaceExists < Minitest::Test
   def test_check_network_interface_exists_success
     mocked_response = ApiStub::Requests::Network::NetworkInterface.create_network_interface_response(@network_client)
     @network_interfaces.stub :get, mocked_response do
-      assert @service.check_network_interface_exists?('fog-test-rg', 'fog-test-network-interface')
+      assert @service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 
   def test_check_network_interface_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_interfaces.stub :get, response do
-      assert !@service.check_network_interface_exists?('fog-test-rg', 'fog-test-network-interface')
+      assert !@service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 
   def test_check_network_interface_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_interfaces.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_network_interface_exists?('fog-test-rg', 'fog-test-network-interface') }
+      assert_raises(RuntimeError) { @service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface') }
     end
   end
 end

--- a/test/requests/network/test_check_public_ip_exists.rb
+++ b/test/requests/network/test_check_public_ip_exists.rb
@@ -10,21 +10,21 @@ class TestCheckPublicIpExists < Minitest::Test
 
   def test_check_public_ip_exists_success
     @public_ips.stub :get, true do
-      assert @service.check_public_ip_exists?('fog-test-rg', 'fog-test-public-ip')
+      assert @service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 
   def test_check_public_ip_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @public_ips.stub :get, response do
-      assert !@service.check_public_ip_exists?('fog-test-rg', 'fog-test-public-ip')
+      assert !@service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 
   def test_check_public_ip_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @public_ips.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_public_ip_exists?('fog-test-rg', 'fog-test-public-ip') }
+      assert_raises(RuntimeError) { @service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip') }
     end
   end
 end

--- a/test/requests/network/test_check_subnet_exists.rb
+++ b/test/requests/network/test_check_subnet_exists.rb
@@ -11,21 +11,21 @@ class TestCheckSubnetExists < Minitest::Test
   def test_check_subnet_exists_success
     mocked_response = ApiStub::Requests::Network::Subnet.create_subnet_response(@network_client)
     @subnets.stub :get, mocked_response do
-      assert @service.check_subnet_exists?('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
+      assert @service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
     end
   end
 
   def test_check_subnet_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @subnets.stub :get, response do
-      assert !@service.check_subnet_exists?('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
+      assert !@service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
     end
   end
 
   def test_check_subnet_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @subnets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_subnet_exists?('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet') }
+      assert_raises(RuntimeError) { @service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet') }
     end
   end
 end

--- a/test/requests/network/test_check_virtual_network_exists.rb
+++ b/test/requests/network/test_check_virtual_network_exists.rb
@@ -10,21 +10,21 @@ class TestCheckVirtualNetworkExists < Minitest::Test
 
   def test_check_virtual_network_exists_success
     @virtual_networks.stub :get, true do
-      assert @service.check_virtual_network_exists?('fog-test-rg', 'fog-test-virtual-network')
+      assert @service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network')
     end
   end
 
   def test_check_virtual_network_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @virtual_networks.stub :get, response do
-      assert !@service.check_virtual_network_exists?('fog-test-rg', 'fog-test-virtual-network')
+      assert !@service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network')
     end
   end
 
   def test_check_virtual_network_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @virtual_networks.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_virtual_network_exists?('fog-test-rg', 'fog-test-virtual-network') }
+      assert_raises(RuntimeError) { @service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network') }
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_connection_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_connection_exists.rb
@@ -11,21 +11,21 @@ class TestCheckVirtualNetworkGatewayConnectionExists < Minitest::Test
   def test_check_vnet_gateway_connection_exists_success
     mocked_response = ApiStub::Requests::Network::VirtualNetworkGatewayConnection.create_virtual_network_gateway_connection_response(@network_client)
     @gateway_connections.stub :get, mocked_response do
-      assert_equal @service.check_vnet_gateway_connection_exists?('fog-test-rg', 'fog-test-gateway-connection'), true
+      assert_equal @service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection'), true
     end
   end
 
   def test_check_vnet_gateway_connection_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @gateway_connections.stub :get, response do
-      assert !@service.check_vnet_gateway_connection_exists?('fog-test-rg', 'fog-test-gateway-connection')
+      assert !@service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection')
     end
   end
 
   def test_check_vnet_gateway_connection_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @gateway_connections.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_connection_exists?('fog-test-rg', 'fog-test-gateway-connection') }
+      assert_raises(RuntimeError) { @service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection') }
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_exists.rb
@@ -11,21 +11,21 @@ class TestCheckVirtualNetworkGatewayExists < Minitest::Test
   def test_check_vnet_gateway_exists_success
     mocked_response = ApiStub::Requests::Network::VirtualNetworkGateway.create_virtual_network_gateway_response(@network_client)
     @network_gateways.stub :get, mocked_response do
-      assert_equal @service.check_vnet_gateway_exists?('fog-test-rg', 'fog-test-network-gateway'), true
+      assert_equal @service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway'), true
     end
   end
 
   def test_check_vnet_gateway_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_gateways.stub :get, response do
-      assert !@service.check_vnet_gateway_exists?('fog-test-rg', 'fog-test-network-gateway')
+      assert !@service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway')
     end
   end
 
   def test_check_vnet_gateway_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_exists?('fog-test-rg', 'fog-test-network-gateway') }
+      assert_raises(RuntimeError) { @service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway') }
     end
   end
 end

--- a/test/requests/resources/test_check_azure_resource_exists.rb
+++ b/test/requests/resources/test_check_azure_resource_exists.rb
@@ -11,12 +11,12 @@ class TestCheckAzureResourceExists < Minitest::Test
   def test_tag_resource_success
     @resources.stub :check_existence, true do
         resource_id = '/subscriptions/########-####-####-####-############/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.Network/{PROVIDER-NAME}/{RESOURCE-NAME}'
-        assert_equal @service.check_azure_resource_exists?(resource_id, '2016-09-01'), true
+        assert_equal @service.check_azure_resource_exists(resource_id, '2016-09-01'), true
     end
   end
 
   def test_invalid_resource_id_exeception
     resource_id = 'Invalid-Resource-ID'
-    assert_raises(RuntimeError) { @service.check_azure_resource_exists?(resource_id, '2016-09-01') }
+    assert_raises(RuntimeError) { @service.check_azure_resource_exists(resource_id, '2016-09-01') }
   end
 end

--- a/test/requests/resources/test_check_deployment_exists.rb
+++ b/test/requests/resources/test_check_deployment_exists.rb
@@ -10,20 +10,20 @@ class TestGetDeployment < Minitest::Test
 
   def test_check_deployment_exists_success
     @deployments.stub :check_existence, true do
-      assert @service.check_deployment_exists?('fog-test-rg', 'fog-test-deployment')
+      assert @service.check_deployment_exists('fog-test-rg', 'fog-test-deployment')
     end
   end
 
   def test_check_deployment_exists_failure
     @deployments.stub :check_existence, false do
-      assert !@service.check_deployment_exists?('fog-test-rg', 'fog-test-deployment')
+      assert !@service.check_deployment_exists('fog-test-rg', 'fog-test-deployment')
     end
   end
 
   def test_check_deployment_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :check_existence, response do
-      assert_raises(RuntimeError) { @service.check_deployment_exists?('fog-test-rg', 'fog-test-deployment') }
+      assert_raises(RuntimeError) { @service.check_deployment_exists('fog-test-rg', 'fog-test-deployment') }
     end
   end
 end

--- a/test/requests/resources/test_check_resource_group_exists.rb
+++ b/test/requests/resources/test_check_resource_group_exists.rb
@@ -10,20 +10,20 @@ class TestGetResourceGroup < Minitest::Test
 
   def test_check_resource_group_exists_success
     @resource_groups.stub :check_existence, true do
-      assert @service.check_resource_group_exists?('fog-test-rg')
+      assert @service.check_resource_group_exists('fog-test-rg')
     end
   end
 
   def test_check_resource_group_exists_failure
     @resource_groups.stub :check_existence, false do
-      assert !@service.check_resource_group_exists?('fog-test-rg')
+      assert !@service.check_resource_group_exists('fog-test-rg')
     end
   end
 
   def test_check_resource_group_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :check_existence, response do
-      assert_raises(RuntimeError) { @service.check_resource_group_exists?('fog-test-rg') }
+      assert_raises(RuntimeError) { @service.check_resource_group_exists('fog-test-rg') }
     end
   end
 end

--- a/test/requests/storage/test_check_container_exists.rb
+++ b/test/requests/storage/test_check_container_exists.rb
@@ -12,7 +12,7 @@ class TestCheckContainerExists < Minitest::Test
 
   def test_check_container_exists_success
     @blob_client.stub :get_container_properties, @container do
-      assert_equal @service.check_container_exists?('test_container'), true
+      assert_equal @service.check_container_exists('test_container'), true
     end
   end
 end

--- a/test/requests/storage/test_check_storage_account_exists.rb
+++ b/test/requests/storage/test_check_storage_account_exists.rb
@@ -12,21 +12,21 @@ class TestCheckStorageAccountExists < Minitest::Test
   def test_check_storage_account_exists_success
     response_body = ApiStub::Requests::Storage::StorageAccount.storage_account_request(@storage_mgmt_client)
     @storage_accounts.stub :get_properties, response_body do
-      assert @service.check_storage_account_exists?('fog_test_rg', 'fogtestsasecond')
+      assert @service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond')
     end
   end
 
   def test_check_storage_account_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @storage_accounts.stub :get_properties, response do
-      assert !@service.check_storage_account_exists?('fog_test_rg', 'fogtestsasecond')
+      assert !@service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond')
     end
   end
 
   def test_check_storage_account_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @storage_accounts.stub :get_properties, response do
-      assert_raises(RuntimeError) { @service.check_storage_account_exists?('fog_test_rg', 'fogtestsasecond') }
+      assert_raises(RuntimeError) { @service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
@@ -11,21 +11,21 @@ class TestCheckTrafficManagerEndpointExists < Minitest::Test
   def test_check_traffic_manager_endpoint_exists_success
     mocked_response = ApiStub::Requests::TrafficManager::TrafficManagerEndPoint.create_traffic_manager_endpoint_response(@traffic_manager_client)
     @end_points.stub :get, mocked_response do
-      assert @service.check_traffic_manager_endpoint_exists?('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
+      assert @service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
     end
   end
 
   def test_check_traffic_manager_endpoint_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'code' => 'NotFound' ) }
     @end_points.stub :get, response do
-      assert !@service.check_traffic_manager_endpoint_exists?('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
+      assert !@service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
     end
   end
 
   def test_check_traffic_manager_endpoint_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @end_points.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_endpoint_exists?('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type') }
+      assert_raises(RuntimeError) { @service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
@@ -11,21 +11,21 @@ class TestCheckTrafficManagerProfileExists < Minitest::Test
   def test_check_traffic_manager_profile_exists_success
     mocked_response = ApiStub::Requests::TrafficManager::TrafficManagerProfile.create_traffic_manager_profile_response(@traffic_manager_client)
     @profiles.stub :get, mocked_response do
-      assert @service.check_traffic_manager_profile_exists?('fog-test-rg', 'fog-test-profile')
+      assert @service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile')
     end
   end
 
   def test_check_traffic_manager_profile_exists_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @profiles.stub :get, response do
-      assert !@service.check_traffic_manager_profile_exists?('fog-test-rg', 'fog-test-profile')
+      assert !@service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile')
     end
   end
 
   def test_check_traffic_manager_profile_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @profiles.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_profile_exists?('fog-test-rg', 'fog-test-profile') }
+      assert_raises(RuntimeError) { @service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile') }
     end
   end
 end


### PR DESCRIPTION
Currently we have implemented requests to add 'exists' functionality in Fog-ARM. These request files contains '?' as part of their names. Windows OS doesn't allow us to create a file name having special character in the file name. So Windows users will be unable to pull this latest change.
Updated file names.