### PR TITLE
Allow for nokogiri 1.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script: sh rake-script.sh
 matrix:
   fast_finish: true
   include:
+    - rvm: 2.0.0
     - rvm: 2.1.0
     - rvm: 2.1.1
     - rvm: 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ script: sh rake-script.sh
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.0.0
     - rvm: 2.1.0
     - rvm: 2.1.1
     - rvm: 2.1.5

--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/fog/fog-azure-rm'
   spec.rdoc_options = %w[--charset=UTF-8]
   spec.extra_rdoc_files = %w[README.md]
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.0.0'
   spec.post_install_message = 'Thanks for installing!'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.8.4'
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_traffic_manager', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_sql', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
-  spec.add_dependency 'azure-storage', '~> 0.12.1.preview'
+  spec.add_dependency 'azure-storage', '>= 0.11.5.preview', '< 1.0'
   spec.add_dependency 'vhd', '0.0.4'
 end

--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/fog/fog-azure-rm'
   spec.rdoc_options = %w[--charset=UTF-8]
   spec.extra_rdoc_files = %w[README.md]
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
   spec.post_install_message = 'Thanks for installing!'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.8.4'

--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_traffic_manager', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_sql', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
-  spec.add_dependency 'azure-storage', '~> 0.11.5.preview'
+  spec.add_dependency 'azure-storage', '~> 0.12.1.preview'
   spec.add_dependency 'vhd', '0.0.4'
 end

--- a/lib/fog/azurerm/version.rb
+++ b/lib/fog/azurerm/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AzureRM
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end


### PR DESCRIPTION
### Motivation of PR
There is a transitive dependency on nokogiri that recently had a couple of security flaws. We now would like to use fog-azure-rm at the same time as nokogiri 1.7.1, the version that fixes these issues.

### Content of our PR
Bump to version 0.3.1 with a dependency to azure-store 0.12.1.preview to allow for nokogiri 1.7.1

Signed-off-by: Eric Promislow <eric.promislow@gmail.com>