### PR TITLE
Removed save method from AccessPolicyEntry model

### DIFF
--- a/lib/fog/azurerm/models/key_vault/access_policy_entry.rb
+++ b/lib/fog/azurerm/models/key_vault/access_policy_entry.rb
@@ -21,10 +21,6 @@ module Fog
 
           access_policy_entry_hash
         end
-
-        def save
-          requires :object_id, :tenant_id, :keys, :secrets
-        end
       end
     end
   end


### PR DESCRIPTION
Existing `AccessPolicyEntry` model contained a `save` method which was not needed for that model. That method has been removed.