### PR TITLE
fog-azure-rm release v0.3.3

### DIFF
--- a/lib/fog/azurerm/version.rb
+++ b/lib/fog/azurerm/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AzureRM
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
**Added:**
- Compute Service - Added support to create availability set with managed disk support

**Changed:**
- Compute Service - Provided option to configure fault and update domain values
- Removed dependency on Rest Client
- azure-storage dependency fixed to 0.11.5.preview (to enable use with ruby 2.0.0)

**Fixed:**
- Unit tests - Storage and Compute