### PR TITLE
Add recordset models

### DIFF
--- a/AboutThisBranch.txt
+++ b/AboutThisBranch.txt
@@ -1,0 +1,2 @@
+New Fog models for RecordSet types 'A' and 'CNAME' have been created. Now instead of using the Azure SDK models for 'A' 
+and 'CNAME' type RecordSets we have our very own Fog models present. Changes have been incorporated and tested.

--- a/lib/fog/azurerm/models/dns/a_record.rb
+++ b/lib/fog/azurerm/models/dns/a_record.rb
@@ -1,0 +1,16 @@
+module Fog
+  module DNS
+    class AzureRM
+      # This class is giving an implementation of 'A' RecordSet type
+      class ARecord < Fog::Model
+        attribute :ipv4address
+
+        def self.parse(arecord)
+          hash = {}
+          hash['ipv4address'] = arecord.ipv4address
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/azurerm/models/dns/a_record.rb
+++ b/lib/fog/azurerm/models/dns/a_record.rb
@@ -6,8 +6,7 @@ module Fog
         attribute :ipv4address
 
         def self.parse(arecord)
-          hash = {}
-          hash['ipv4address'] = arecord.ipv4address
+          hash = get_hash_from_object(arecord)
           hash
         end
       end

--- a/lib/fog/azurerm/models/dns/cname_record.rb
+++ b/lib/fog/azurerm/models/dns/cname_record.rb
@@ -6,8 +6,7 @@ module Fog
         attribute :cname
 
         def self.parse(cnamerecord)
-          hash = {}
-          hash['cname'] = cnamerecord.cname
+          hash = get_hash_from_object(cnamerecord)
           hash
         end
       end

--- a/lib/fog/azurerm/models/dns/cname_record.rb
+++ b/lib/fog/azurerm/models/dns/cname_record.rb
@@ -1,0 +1,16 @@
+module Fog
+  module DNS
+    class AzureRM
+      # This class is giving an implementation of 'CNAME' RecordSet type
+      class CnameRecord < Fog::Model
+        attribute :cname
+
+        def self.parse(cnamerecord)
+          hash = {}
+          hash['cname'] = cnamerecord.cname
+          hash
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/azurerm/models/dns/record_set.rb
+++ b/lib/fog/azurerm/models/dns/record_set.rb
@@ -15,12 +15,9 @@ module Fog
         attribute :a_records
 
         def self.parse(recordset)
-          hash = {}
-          hash['id'] = recordset.id
-          hash['name'] = recordset.name
+          hash = get_hash_from_object(recordset)
           hash['resource_group'] = get_resource_group_from_id(recordset.id)
           hash['zone_name'] = get_record_set_from_id(recordset.id)
-          hash['type'] = recordset.type
           type = get_type_from_recordset_type(recordset.type)
 
           hash['records'] = []
@@ -36,22 +33,21 @@ module Fog
           end
 
           unless recordset.arecords.nil?
-            a_record_fog_arr = []
+            a_records = []
             recordset.arecords.each do |record|
-              a_record_fog = Fog::DNS::AzureRM::ARecord.new
-              a_record_fog.merge_attributes(Fog::DNS::AzureRM::ARecord.parse(record))
-              a_record_fog_arr.push(a_record_fog)
+              a_record = Fog::DNS::AzureRM::ARecord.new
+              a_record.merge_attributes(Fog::DNS::AzureRM::ARecord.parse(record))
+              a_records.push(a_record)
             end
-            hash['a_records'] = a_record_fog_arr
+            hash['a_records'] = a_records
           end
 
           unless recordset.cname_record.nil?
-            cname_record_fog = Fog::DNS::AzureRM::CnameRecord.new
-            cname_record_fog.merge_attributes(Fog::DNS::AzureRM::CnameRecord.parse(recordset.cname_record))
-            hash['cname_record'] = cname_record_fog
+            cname_record = Fog::DNS::AzureRM::CnameRecord.new
+            cname_record.merge_attributes(Fog::DNS::AzureRM::CnameRecord.parse(recordset.cname_record))
+            hash['cname_record'] = cname_record
           end
 
-          hash['ttl'] = recordset.ttl
           hash
         end
 

--- a/lib/fog/azurerm/requests/dns/create_or_update_record_set.rb
+++ b/lib/fog/azurerm/requests/dns/create_or_update_record_set.rb
@@ -34,9 +34,10 @@ module Fog
             end
             record_set.arecords = a_type_records_array
           when 'CNAME'
-            record_set.cname_record = record_set_params[:records].first # because cname only has 1 value and we know the object is an array passed in.
+            cname_record = Azure::ARM::Dns::Models::CnameRecord.new
+            cname_record.cname = record_set_params[:records].first # because cname only has 1 value and we know the object is an array passed in.
+            record_set.cname_record = cname_record
           end
-
           record_set
         end
       end

--- a/test/integration/record_set.rb
+++ b/test/integration/record_set.rb
@@ -57,13 +57,13 @@ begin
     type: 'CNAME',
     ttl: 60
   )
-  puts "Created CNAME type record set: #{record_set.name}"
+  puts "Created CNAME type record set: #{record_set.inspect}"
 
   ########################################################################################################################
   ######################                        Create A Type Record Set in a Zone                   ######################
   ########################################################################################################################
 
-  dns.record_sets.create(
+  record_set = dns.record_sets.create(
     name: 'TestRS2',
     resource_group: 'TestRG-RS',
     zone_name: 'test-zone.com',
@@ -71,14 +71,14 @@ begin
     type: 'A',
     ttl: 60
   )
-  puts "Created A type record set: #{record_set.name}"
+  puts "Created A type record set: #{record_set.inspect}"
 
   ########################################################################################################################
   ######################                Get And Destroy CNAME Type Record Set in a Zone             ######################
   ########################################################################################################################
 
   record_set = dns.record_sets.get('TestRG-RS', 'TestRS1', 'test-zone.com', 'CNAME')
-  puts "Get CNAME Type record set: #{record_set.name}"
+  puts "Get CNAME Type record set: #{record_set.inspect}"
   record_set.destroy
 
   ########################################################################################################################
@@ -86,7 +86,7 @@ begin
   ########################################################################################################################
 
   record_set = dns.record_sets.get('TestRG-RS', 'TestRS2', 'test-zone.com', 'A')
-  puts "Get A Type record set: #{record_set.name}"
+  puts "Get A Type record set: #{record_set.inspect}"
 
   ########################################################################################################################
   ######################                               Update a Record Set                          ######################


### PR DESCRIPTION
Fog Models for DNS RecordSet types 'A' and 'CNAME' have been added.