### PR TITLE
Fixed 'check_existence' Request Methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ matrix:
   allow_failures:
     - rvm: jruby-head
 
-notifications:
-  email:
-    recipients:
-      - dev-oneops@confiz.com
-    on_success: always
-    on_failure: always
-
 addons:
   code_climate:
     repo_token: b1401494baa004d90402414cb33a7fc6420fd3693e60c677a120ddefd7d84cfd

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ matrix:
   allow_failures:
     - rvm: jruby-head
 
+notifications:
+  email:
+    recipients:
+      - dev-oneops@confiz.com
+    on_success: always
+    on_failure: always
+
 addons:
   code_climate:
     repo_token: b1401494baa004d90402414cb33a7fc6420fd3693e60c677a120ddefd7d84cfd

--- a/lib/fog/azurerm/constants.rb
+++ b/lib/fog/azurerm/constants.rb
@@ -34,6 +34,7 @@ ENVIRONMENT_AZURE_GERMAN_CLOUD = 'AzureGermanCloud'.freeze
 # MsRestAzure::AzureOperationError class Error Codes
 ERROR_CODE_RESOURCE_NOT_FOUND = 'ResourceNotFound'.freeze
 ERROR_CODE_NOT_FOUND = 'NotFound'.freeze
+ERROR_CODE_RESOURCE_GROUP_NOT_FOUND = 'ResourceGroupNotFound'.freeze
 
 PLATFORM_LINUX = 'linux'.freeze
 
@@ -65,3 +66,5 @@ AS_SKU_ALIGNED = 'Aligned'.freeze
 # The tag key and tag value for creating a temporary storage account for generalized image
 TEMPORARY_STORAGE_ACCOUNT_TAG_KEY = 'generalized_image'.freeze
 TEMPORARY_STORAGE_ACCOUNT_TAG_VALUE = 'delete'.freeze
+
+HTTP_NOT_FOUND = 404

--- a/lib/fog/azurerm/requests/application_gateway/check_ag_exists.rb
+++ b/lib/fog/azurerm/requests/application_gateway/check_ag_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Application Gateway #{application_gateway_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Application Gateway #{application_gateway_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/compute/check_availability_set_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_availability_set_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Availability set #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Availability set #{name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/compute/check_managed_disk_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_managed_disk_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Managed Disk #{disk_name} exist."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.error_code == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Managed Disk #{disk_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/compute/check_vm_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_vm_exists.rb
@@ -13,11 +13,11 @@ module Fog
               @compute_mgmt_client.virtual_machines.get(resource_group, name, 'instanceView')
             end
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Virtual machine #{name} doesn't exist."
               return false
-            else
-              raise_azure_exception(e, msg)
             end
           end
           if async

--- a/lib/fog/azurerm/requests/compute/check_vm_extension_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_vm_extension_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Virtual Machine Extension #{vm_extension_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Virtual machine #{vm_extension_name} doesn't exist."
-              false
-            else
+            if check_resource_existence_exception(e)
               raise_azure_exception(e, msg)
+            else
+              Fog::Logger.debug "Virtual Machine Extension #{vm_extension_name} doesn't exist."
+              false
             end
           end
         end

--- a/lib/fog/azurerm/requests/dns/check_record_set_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_record_set_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Record set #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['code'] == 'NotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Record set #{name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/dns/check_zone_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_zone_exists.rb
@@ -11,7 +11,7 @@ module Fog
           rescue MsRestAzure::AzureOperationError => e
             if resource_not_found?(e)
               Fog::Logger.debug "Zone #{name} doesn't exist."
-              zone = nil
+              return false
             else
               raise_azure_exception(e, msg)
             end

--- a/lib/fog/azurerm/requests/dns/check_zone_exists.rb
+++ b/lib/fog/azurerm/requests/dns/check_zone_exists.rb
@@ -9,10 +9,11 @@ module Fog
           begin
             zone = @dns_client.zones.get(resource_group, name)
           rescue MsRestAzure::AzureOperationError => e
-            if !e.body['error'].nil? && e.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND
-              zone = nil
-            else
+            if check_resource_existence_exception(e)
               raise_azure_exception(e, msg)
+            else
+              Fog::Logger.debug "Zone #{name} doesn't exist."
+              zone = nil
             end
           rescue => e
             Fog::Logger.debug e[:error][:code]

--- a/lib/fog/azurerm/requests/key_vault/check_vault_exists.rb
+++ b/lib/fog/azurerm/requests/key_vault/check_vault_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Vault #{vault_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Vault #{vault_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_express_route_cir_auth_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_express_route_cir_auth_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'NotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Express Route Circuit Authorization #{authorization_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_express_route_circuit_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_express_route_circuit_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Express Route Circuit #{circuit_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Express Route Circuit #{circuit_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_load_balancer_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_load_balancer_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Load Balancer #{load_balancer_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Load Balancer #{load_balancer_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_local_net_gateway_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_local_net_gateway_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Local Network Gateway #{local_network_gateway_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_net_sec_group_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_net_sec_group_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Network Security Group #{security_group_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Network Security Group #{security_group_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_net_sec_rule_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_net_sec_rule_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Network Security Rule #{security_rule_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if !e.body['error'].nil? && (e.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND || e.body['error']['code'] == ERROR_CODE_NOT_FOUND)
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Network Security Rule #{security_rule_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_network_interface_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_network_interface_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Network Interface #{nic_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Network Interface #{nic_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_public_ip_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_public_ip_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Public IP #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Public IP #{name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_subnet_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_subnet_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Subnet #{subnet_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if !e.body['error'].nil? && (e.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND || e.body['error']['code'] == ERROR_CODE_NOT_FOUND)
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Subnet #{subnet_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_virtual_network_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_virtual_network_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Virtual Network #{name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.error_code == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Virtual Network #{name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_vnet_gateway_connection_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_vnet_gateway_connection_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Virtual Network Gateway Connection #{gateway_connection_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Virtual Network Gateway Connection #{gateway_connection_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/network/check_vnet_gateway_exists.rb
+++ b/lib/fog/azurerm/requests/network/check_vnet_gateway_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Virtual Network Gateway #{network_gateway_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Virtual Network Gateway #{network_gateway_name} doesn't exist."
               false
-            else
-              raise_azure_exception(e, msg)
             end
           end
         end

--- a/lib/fog/azurerm/requests/storage/check_storage_account_exists.rb
+++ b/lib/fog/azurerm/requests/storage/check_storage_account_exists.rb
@@ -9,11 +9,11 @@ module Fog
           begin
             storage_account = @storage_mgmt_client.storage_accounts.get_properties(resource_group_name, storage_account_name)
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
+            if check_resource_existence_exception(e)
+              raise_azure_exception(e, msg)
+            else
               Fog::Logger.debug "Storage Account #{storage_account_name} doesn't exist."
               return false
-            else
-              raise_azure_exception(e, msg)
             end
           end
 

--- a/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_endpoint_exists.rb
+++ b/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_endpoint_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Traffic Manager Endpoint #{traffic_manager_end_point} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['code'] == 'NotFound'
-              Fog::Logger.debug "Traffic Manager Endpoint #{traffic_manager_end_point} doesn't exist."
-              false
-            else
+            if check_resource_existence_exception(e)
               raise_azure_exception(e, msg)
+            else
+              Fog::Logger.debug "Traffic Manager Endpoint #{traffic_manager_end_point} doesn't exist."
+              return false
             end
           end
         end

--- a/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_profile_exists.rb
+++ b/lib/fog/azurerm/requests/traffic_manager/check_traffic_manager_profile_exists.rb
@@ -11,11 +11,11 @@ module Fog
             Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} exists."
             true
           rescue MsRestAzure::AzureOperationError => e
-            if e.body['error']['code'] == 'ResourceNotFound'
-              Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} doesn't exist."
-              false
-            else
+            if check_resource_existence_exception(e)
               raise_azure_exception(e, msg)
+            else
+              Fog::Logger.debug "Traffic Manager Profile #{traffic_manager_profile_name} doesn't exist."
+              return false
             end
           end
         end

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -166,3 +166,13 @@ def parse_storage_object(object)
   data['etag'].delete!('"')
   data
 end
+
+def check_resource_existence_exception(azure_operation_error)
+  unless azure_operation_error.response['status'] != HTTP_NOT_FOUND
+    if azure_operation_error.body['code']
+      !(azure_operation_error.body['code'] == ERROR_CODE_NOT_FOUND)
+    else
+      !(azure_operation_error.body['error']['code'] == ERROR_CODE_NOT_FOUND || azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_GROUP_NOT_FOUND || azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND)
+    end
+  end
+end

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -169,10 +169,13 @@ end
 
 def resource_not_found?(azure_operation_error)
   is_found = false
+  puts "HAHAHAHAHAHA #{azure_operation_error.inspect}"
   if azure_operation_error.response.status == HTTP_NOT_FOUND
     if azure_operation_error.body['code']
+      puts "#{azure_operation_error.body['code']}"
       is_found = azure_operation_error.body['code'] == ERROR_CODE_NOT_FOUND
     elsif azure_operation_error.body['error']
+      puts "#{azure_operation_error.body['error']['code']}"
       is_found = azure_operation_error.body['error']['code'] == ERROR_CODE_NOT_FOUND ||
                  azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_GROUP_NOT_FOUND ||
                  azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND ||

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -169,13 +169,10 @@ end
 
 def resource_not_found?(azure_operation_error)
   is_found = false
-  puts "HAHAHAHAHAHA #{azure_operation_error.inspect}"
   if azure_operation_error.response.status == HTTP_NOT_FOUND
     if azure_operation_error.body['code']
-      puts "#{azure_operation_error.body['code']}"
       is_found = azure_operation_error.body['code'] == ERROR_CODE_NOT_FOUND
     elsif azure_operation_error.body['error']
-      puts "#{azure_operation_error.body['error']['code']}"
       is_found = azure_operation_error.body['error']['code'] == ERROR_CODE_NOT_FOUND ||
                  azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_GROUP_NOT_FOUND ||
                  azure_operation_error.body['error']['code'] == ERROR_CODE_RESOURCE_NOT_FOUND ||

--- a/test/requests/application_gateway/test_check_ag_exists.rb
+++ b/test/requests/application_gateway/test_check_ag_exists.rb
@@ -20,12 +20,13 @@ class TestCheckAGExists < Minitest::Test
     @gateways.stub :get, response do
       assert !@service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end
+
   end
 
   def test_check_ag_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_ag_exists('fog-test-rg', 'fogRM-rg') }
+      assert !@service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end
   end
 end

--- a/test/requests/application_gateway/test_check_ag_exists.rb
+++ b/test/requests/application_gateway/test_check_ag_exists.rb
@@ -16,15 +16,14 @@ class TestCheckAGExists < Minitest::Test
   end
 
   def test_check_ag_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @gateways.stub :get, response do
       assert !@service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end
-
   end
 
   def test_check_ag_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @gateways.stub :get, response do
       assert !@service.check_ag_exists('fog-test-rg', 'fogRM-rg')
     end

--- a/test/requests/compute/test_check_availability_set_exists.rb
+++ b/test/requests/compute/test_check_availability_set_exists.rb
@@ -16,16 +16,16 @@ class TestCheckAvailabilitySetExists < Minitest::Test
   end
 
   def test_check_availability_set_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @availability_sets.stub :get, response do
       assert !@service.check_availability_set_exists('myrg1', 'myavset1')
     end
   end
 
   def test_check_availability_set_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @availability_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_availability_set_exists('myrg1', 'myavset1') }
+      assert !@service.check_availability_set_exists('myrg1', 'myavset1')
     end
   end
 end

--- a/test/requests/compute/test_check_managed_disk_exists.rb
+++ b/test/requests/compute/test_check_managed_disk_exists.rb
@@ -16,16 +16,16 @@ class TestCheckManagedDiskExists < Minitest::Test
   end
 
   def test_check_managed_disk_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @managed_disks.stub :get, response do
       assert !@service.check_managed_disk_exists('myrg1', 'mydisk1')
     end
   end
 
   def test_check_managed_disk_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @managed_disks.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_managed_disk_exists('myrg1', 'mydisk1') }
+      assert !@service.check_managed_disk_exists('myrg1', 'mydisk1')
     end
   end
 end

--- a/test/requests/compute/test_check_vm_exists.rb
+++ b/test/requests/compute/test_check_vm_exists.rb
@@ -16,16 +16,16 @@ class TestCheckVirtualMachineExists < Minitest::Test
   end
 
   def test_check_vm_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @virtual_machines.stub :get, response do
       assert !@service.check_vm_exists('fog-test-rg', 'fog-test-server', false)
     end
   end
 
   def test_check_vm_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @virtual_machines.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_exists('fog-test-rg', 'fog-test-server', false) }
+      assert !@service.check_vm_exists('fog-test-rg', 'fog-test-server', false)
     end
   end
 end

--- a/test/requests/compute/test_check_vm_extension_exists.rb
+++ b/test/requests/compute/test_check_vm_extension_exists.rb
@@ -16,16 +16,16 @@ class TestCheckVMExtensionExists < Minitest::Test
   end
 
   def test_check_vm_extension_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @vm_extension.stub :get, response do
       assert !@service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
     end
   end
 
   def test_check_vm_extension_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @vm_extension.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension') }
+      assert !@service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
     end
   end
 end

--- a/test/requests/dns/test_check_record_set_exists.rb
+++ b/test/requests/dns/test_check_record_set_exists.rb
@@ -16,16 +16,16 @@ class TestCheckRecordSetExists < Minitest::Test
   end
 
   def test_check_record_set_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'code' => 'NotFound' ) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'code' => 'NotFound' ) }
     @record_sets.stub :get, response do
       assert !@service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
     end
   end
 
   def test_check_record_set_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @record_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
+      assert !@service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME')
     end
   end
 end

--- a/test/requests/dns/test_check_zone_exists.rb
+++ b/test/requests/dns/test_check_zone_exists.rb
@@ -25,11 +25,9 @@ class TestCheckZoneExists < Minitest::Test
   end
 
   def test_check_zone_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @zones.stub :get, response do
-      assert_raises RuntimeError do
-        @service.check_zone_exists('fog-test-rg', 'zone_name')
-      end
+      assert !@service.check_zone_exists('fog-test-rg', 'zone_name')
     end
   end
 end

--- a/test/requests/key_vault/test_check_vault_exists.rb
+++ b/test/requests/key_vault/test_check_vault_exists.rb
@@ -16,16 +16,16 @@ class TestCheckVaultExists < Minitest::Test
   end
 
   def test_check_vault_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @vaults.stub :get, response do
       assert !@service.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 
   def test_check_vault_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @vaults.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vault_exists('fog-test-rg', 'fog-test-kv') }
+      assert !@service.check_vault_exists('fog-test-rg', 'fog-test-kv')
     end
   end
 end

--- a/test/requests/network/test_check_express_route_cir_auth_exists.rb
+++ b/test/requests/network/test_check_express_route_cir_auth_exists.rb
@@ -16,16 +16,16 @@ class TestCheckExpressRouteCirAuthExists < Minitest::Test
   end
 
   def test_check_express_route_cir_auth_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'NotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'NotFound' }) }
     @circuit_authorization.stub :get, response do
       assert !@service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name')
     end
   end
 
   def test_check_express_route_cir_auth_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @circuit_authorization.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name') }
+      assert !@service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name')
     end
   end
 end

--- a/test/requests/network/test_check_express_route_circuit_exists.rb
+++ b/test/requests/network/test_check_express_route_circuit_exists.rb
@@ -16,16 +16,16 @@ class TestCheckExpressRouteCircuitExists < Minitest::Test
   end
 
   def test_check_express_route_circuit_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @circuit.stub :get, response do
       assert !@service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit')
     end
   end
 
   def test_check_express_route_circuit_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @circuit.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit') }
+      assert !@service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit')
     end
   end
 end

--- a/test/requests/network/test_check_load_balancer_exists.rb
+++ b/test/requests/network/test_check_load_balancer_exists.rb
@@ -16,16 +16,16 @@ class TestCheckLoadBalancerExists < Minitest::Test
   end
 
   def test_check_load_balancer_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @load_balancers.stub :get, response do
       assert !@service.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 
   def test_check_load_balancer_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @load_balancers.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_load_balancer_exists('fog-test-rg', 'mylb1') }
+      assert !@service.check_load_balancer_exists('fog-test-rg', 'mylb1')
     end
   end
 end

--- a/test/requests/network/test_check_local_net_gateway_exists.rb
+++ b/test/requests/network/test_check_local_net_gateway_exists.rb
@@ -16,16 +16,16 @@ class TestCheckLocalNetworkGatewayExists < Minitest::Test
   end
 
   def test_check_virtual_network_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @local_network_gateways.stub :get, response do
       assert !@service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway')
     end
   end
 
   def test_check_fvirtual_network_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @local_network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway') }
+      assert !@service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway')
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_group_exists.rb
+++ b/test/requests/network/test_check_net_sec_group_exists.rb
@@ -16,16 +16,16 @@ class TestCheckNetworkSecurityGroupExists < Minitest::Test
   end
 
   def test_check_net_sec_group_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_security_groups.stub :get, response do
       assert !@service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg')
     end
   end
 
   def test_check_net_sec_group_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_security_groups.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg') }
+      assert !@service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg')
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_rule_exists.rb
+++ b/test/requests/network/test_check_net_sec_rule_exists.rb
@@ -16,16 +16,16 @@ class TestCheckNetworkSecurityRuleExists < Minitest::Test
   end
 
   def test_check_net_sec_rule_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_security_rules.stub :get, response do
       assert !@service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 
   def test_check_net_sec_rule_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_security_rules.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr') }
+      assert !@service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
     end
   end
 end

--- a/test/requests/network/test_check_network_interface_exists.rb
+++ b/test/requests/network/test_check_network_interface_exists.rb
@@ -16,16 +16,16 @@ class TestCheckNetworkInterfaceExists < Minitest::Test
   end
 
   def test_check_network_interface_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_interfaces.stub :get, response do
       assert !@service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 
   def test_check_network_interface_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_interfaces.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface') }
+      assert !@service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface')
     end
   end
 end

--- a/test/requests/network/test_check_public_ip_exists.rb
+++ b/test/requests/network/test_check_public_ip_exists.rb
@@ -15,16 +15,16 @@ class TestCheckPublicIpExists < Minitest::Test
   end
 
   def test_check_public_ip_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @public_ips.stub :get, response do
       assert !@service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 
   def test_check_public_ip_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @public_ips.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip') }
+      assert !@service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip')
     end
   end
 end

--- a/test/requests/network/test_check_subnet_exists.rb
+++ b/test/requests/network/test_check_subnet_exists.rb
@@ -16,16 +16,16 @@ class TestCheckSubnetExists < Minitest::Test
   end
 
   def test_check_subnet_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @subnets.stub :get, response do
       assert !@service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
     end
   end
 
   def test_check_subnet_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @subnets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet') }
+      assert !@service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
     end
   end
 end

--- a/test/requests/network/test_check_virtual_network_exists.rb
+++ b/test/requests/network/test_check_virtual_network_exists.rb
@@ -15,8 +15,7 @@ class TestCheckVirtualNetworkExists < Minitest::Test
   end
 
   def test_check_virtual_network_exists_failure
-    faraday_response = Faraday::Response.new(nil)
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, faraday_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
 
     @virtual_networks.stub :get, response do
       assert !@service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network')
@@ -24,11 +23,10 @@ class TestCheckVirtualNetworkExists < Minitest::Test
   end
 
   def test_check_virtual_network_exists_exception
-    faraday_response = Faraday::Response.new(nil)
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, faraday_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
 
     @virtual_networks.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network') }
+      assert !@service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network')
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_connection_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_connection_exists.rb
@@ -16,16 +16,16 @@ class TestCheckVirtualNetworkGatewayConnectionExists < Minitest::Test
   end
 
   def test_check_vnet_gateway_connection_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @gateway_connections.stub :get, response do
       assert !@service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection')
     end
   end
 
   def test_check_vnet_gateway_connection_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @gateway_connections.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection') }
+      assert !@service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection')
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_exists.rb
@@ -16,16 +16,16 @@ class TestCheckVirtualNetworkGatewayExists < Minitest::Test
   end
 
   def test_check_vnet_gateway_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @network_gateways.stub :get, response do
       assert !@service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway')
     end
   end
 
   def test_check_vnet_gateway_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway') }
+      assert !@service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway')
     end
   end
 end

--- a/test/requests/storage/test_check_storage_account_exists.rb
+++ b/test/requests/storage/test_check_storage_account_exists.rb
@@ -26,9 +26,9 @@ class TestCheckStorageAccountExists < Minitest::Test
   end
 
   def test_check_storage_account_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @storage_accounts.stub :get_properties, response do
-      assert_raises(RuntimeError) { @service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond') }
+      assert !@service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond')
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
@@ -16,16 +16,16 @@ class TestCheckTrafficManagerEndpointExists < Minitest::Test
   end
 
   def test_check_traffic_manager_endpoint_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'code' => 'NotFound' ) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'code' => 'NotFound' ) }
     @end_points.stub :get, response do
       assert !@service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
     end
   end
 
   def test_check_traffic_manager_endpoint_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @end_points.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type') }
+      assert !@service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type')
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
@@ -16,16 +16,16 @@ class TestCheckTrafficManagerProfileExists < Minitest::Test
   end
 
   def test_check_traffic_manager_profile_exists_failure
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceNotFound' }) }
     @profiles.stub :get, response do
       assert !@service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile')
     end
   end
 
   def test_check_traffic_manager_profile_exists_exception
-    response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
+    response = proc { raise MsRestAzure::AzureOperationError.new(nil, get_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @profiles.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile') }
+      assert !@service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile')
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -824,3 +824,7 @@ def key_vault(service)
     service: service
   )
 end
+
+def get_mock_response
+  mock_response = Faraday::Response.new({'status' => 404})
+end


### PR DESCRIPTION
The 'check_existence' request methods for each resource has been fixed to return false in the following cases
- Resource not found
- Resource's parent resource is not found
- The resource group containing the resource is not found