### PR TITLE
Enhance/enable managed disk deletion async

### DIFF
--- a/lib/fog/azurerm/docs/compute.md
+++ b/lib/fog/azurerm/docs/compute.md
@@ -388,6 +388,8 @@ Get an managed disk object from the get method and then destroy that managed dis
 
 ```ruby
 managed_disk.destroy
+# Can be made asynchronously (is synchronous by default)
+managed_disk.destroy(true)
 ```
 
 ## Check Availability Set Existence

--- a/lib/fog/azurerm/models/compute/managed_disk.rb
+++ b/lib/fog/azurerm/models/compute/managed_disk.rb
@@ -47,7 +47,9 @@ module Fog
         end
 
         def destroy(async = false)
-          service.delete_managed_disk(resource_group_name, name, async)
+          response = service.delete_managed_disk(resource_group_name, name,
+                                                 async)
+          async ? create_fog_async_response(response) : response
         end
 
         private
@@ -70,6 +72,11 @@ module Fog
             creation_data: creation_data,
             encryption_settings: encryption_settings
           }
+        end
+
+        def create_fog_async_response(response, delete_extra_resource = false)
+          disk = Fog::Compute::AzureRM::ManagedDisk.new(service: service)
+          Fog::AzureRM::AsyncResponse.new(disk, response, delete_extra_resource)
         end
       end
     end

--- a/lib/fog/azurerm/models/compute/managed_disk.rb
+++ b/lib/fog/azurerm/models/compute/managed_disk.rb
@@ -46,8 +46,8 @@ module Fog
           merge_attributes(Fog::Compute::AzureRM::ManagedDisk.parse(disk))
         end
 
-        def destroy
-          service.delete_managed_disk(resource_group_name, name)
+        def destroy(async = false)
+          service.delete_managed_disk(resource_group_name, name, async)
         end
 
         private

--- a/lib/fog/azurerm/requests/compute/delete_managed_disk.rb
+++ b/lib/fog/azurerm/requests/compute/delete_managed_disk.rb
@@ -9,15 +9,19 @@ module Fog
           Fog::Logger.debug msg
           begin
             if async
-              @compute_mgmt_client.disks.delete_async(resource_group_name, disk_name)
+              response = @compute_mgmt_client.disks.delete_async(resource_group_name, disk_name)
             else
               @compute_mgmt_client.disks.delete(resource_group_name, disk_name)
             end
           rescue MsRestAzure::AzureOperationError => e
             raise_azure_exception(e, msg)
           end
-          Fog::Logger.debug "Managed Disk #{disk_name} deleted successfully."
-          true
+          if async
+            response
+          else
+            Fog::Logger.debug "Managed Disk #{disk_name} deleted successfully."
+            true
+          end
         end
       end
 

--- a/lib/fog/azurerm/requests/compute/delete_managed_disk.rb
+++ b/lib/fog/azurerm/requests/compute/delete_managed_disk.rb
@@ -4,11 +4,15 @@ module Fog
     class AzureRM
       # Real class for Compute Request
       class Real
-        def delete_managed_disk(resource_group_name, disk_name)
+        def delete_managed_disk(resource_group_name, disk_name, async)
           msg = "Deleting Managed Disk: #{disk_name}"
           Fog::Logger.debug msg
           begin
-            @compute_mgmt_client.disks.delete(resource_group_name, disk_name)
+            if async
+              @compute_mgmt_client.disks.delete_async(resource_group_name, disk_name)
+            else
+              @compute_mgmt_client.disks.delete(resource_group_name, disk_name)
+            end
           rescue MsRestAzure::AzureOperationError => e
             raise_azure_exception(e, msg)
           end

--- a/test/models/compute/test_managed_disk.rb
+++ b/test/models/compute/test_managed_disk.rb
@@ -50,13 +50,19 @@ class TestManagedDisk < Minitest::Test
 
   def test_destroy_method_true_response
     @service.stub :delete_managed_disk, true do
-      assert @managed_disk.destroy
+      assert @managed_disk.destroy(false)
     end
   end
 
   def test_destroy_method_false_response
     @service.stub :delete_managed_disk, false do
-      assert !@managed_disk.destroy
+      assert !@managed_disk.destroy(false)
+    end
+  end
+
+  def test_destroy_method_can_take_params_async
+    @service.stub :delete_managed_disk, true do
+      assert @managed_disk.destroy(true)
     end
   end
 end

--- a/test/models/compute/test_managed_disk.rb
+++ b/test/models/compute/test_managed_disk.rb
@@ -61,8 +61,9 @@ class TestManagedDisk < Minitest::Test
   end
 
   def test_destroy_method_can_take_params_async
-    @service.stub :delete_managed_disk, true do
-      assert @managed_disk.destroy(true)
+    async_response = Concurrent::Promise.execute { 10 }
+    @service.stub :delete_managed_disk, async_response do
+      assert_instance_of Fog::AzureRM::AsyncResponse, @managed_disk.destroy(true)
     end
   end
 end

--- a/test/requests/compute/test_delete_managed_disk.rb
+++ b/test/requests/compute/test_delete_managed_disk.rb
@@ -10,14 +10,14 @@ class TestDeleteManagedDisk < Minitest::Test
 
   def test_delete_managed_disk_success
     @managed_disks.stub :delete, true do
-      assert @service.delete_managed_disk('fog-test-rg', 'test-disk')
+      assert @service.delete_managed_disk('fog-test-rg', 'test-disk', false)
     end
   end
 
   def test_delete_managed_disk_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :delete, response do
-      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_managed_disk('fog-test-rg', 'test-disk') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_managed_disk('fog-test-rg', 'test-disk', false) }
     end
   end
 end


### PR DESCRIPTION
Hi,

This little enhance permite to destroy a managed disk asynchronously, according to azure-sdk method (see: https://github.com/Azure/azure-sdk-for-ruby/blob/84fc2ecb6a4d9fd07bfed0182896901f8bf9df6b/management/azure_mgmt_compute/lib/2017-03-30/generated/azure_mgmt_compute/disks.rb#L240).

Result:
```
client.managed_disks.get('rg', 'disk_name').destroy(true)
=> true
```