### PR TITLE
Resolve fixed mime-types version

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
   spec.add_dependency 'azure-storage', '= 0.11.5.preview'
   spec.add_dependency 'vhd', '0.0.4'
-  spec.add_dependency 'mime-types', '1.25'
+  spec.add_dependency 'mime-types', '>= 1.25', '< 4.0'
 end


### PR DESCRIPTION
Hi,

I've a problem with the new version of the gem because of the mime-types version is fixed and incompatible with the currently used version  in other gem.