### PR TITLE
Fixed mime-type dependency

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
   spec.add_dependency 'azure-storage', '= 0.11.5.preview'
   spec.add_dependency 'vhd', '0.0.4'
-  spec.add_dependency 'mime-types', '1.25'
+  spec.add_dependency 'mime-types', '~> 1.25'
 end


### PR DESCRIPTION
Fixed dependency on mime-types gem. This is a temporary fix until a new version on fog-core is released.