### PR TITLE
Fixed Travis CI Issue of Running on all Ruby Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,17 @@ before_install:
 
 script: bash ./rake-script.sh
 
+rvm:
+  - 2.0.0
+  - 2.1.0
+  - 2.1.1
+  - 2.1.5
+  - 2.2.0
+  - 2.3.0
+  - jruby-head
+
 matrix:
   fast_finish: true
-  include:
-    - rvm: 2.0.0
-    - rvm: 2.1.0
-    - rvm: 2.1.1
-    - rvm: 2.1.5
-    - rvm: 2.2.0
-    - rvm: 2.3.0
-    - rvm: jruby-head
   allow_failures:
     - rvm: jruby-head
 


### PR DESCRIPTION
Travis CI was not running the unit tests against all versions of Ruby specified due to the gem release job. That issue has been fixed.