### PR TITLE
Upgraded the version of mime-types gem

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
   spec.add_dependency 'azure-storage', '= 0.11.5.preview'
   spec.add_dependency 'vhd', '0.0.4'
-  spec.add_dependency 'mime-types', '~> 1.25'
+  spec.add_dependency 'mime-types', '~> 3.1'
 end


### PR DESCRIPTION
fog-azure-rm gem is dependent on **mime-types:1.25** which was released August 30, 2013 and this was creating problems with other application that were using the latest version of mime-types, hence I have upgraded it to **mime-types:3.1**.

I've run both `rake test` and `rake coverage` and the results were positive.