### PR TITLE
Fix raise_azure_exception Method by Creating Custom Fog Exceptions

### DIFF
--- a/lib/fog/azurerm/custom_fog_errors.rb
+++ b/lib/fog/azurerm/custom_fog_errors.rb
@@ -1,21 +1,18 @@
+# This file contains any or all custom Fog errors that we create
 module Fog
-    module AzureRM
-        class CustomAzureOperationError < MsRestAzure::AzureOperationError
-            
-            def initialize(message, azure_exception)
-                super("Exception in #{message}")
-                @request = azure_exception.request.clone
-                @response = azure_exception.response.clone
-            end
-        end
-
-        class CustomAzureCoreHttpError < Azure::Core::Http::HTTPError
-
-            def initialize (description, azure_exception)
-                super("Exception in #{description}")
-                @request = azure_exception.request.clone
-                @response = azure_exception.response.clone
-            end
-        end
+  module AzureRM
+    # This is a custom Fog exception inherited from MsRestAzure::AzureOperationError
+    class CustomAzureOperationError < MsRestAzure::AzureOperationError
+      def initialize(message, azure_exception)
+        super(azure_exception.request, azure_exception.response, azure_exception.body, "Exception in #{message}")
+      end
     end
+
+    # This is a custom Fog exception inherited from Azure::Core::Http::HTTPError
+    class CustomAzureCoreHttpError < Azure::Core::Http::HTTPError
+      def initialize(azure_exception)
+        super(azure_exception.http_response)
+      end
+    end
+  end
 end

--- a/lib/fog/azurerm/custom_fog_errors.rb
+++ b/lib/fog/azurerm/custom_fog_errors.rb
@@ -1,0 +1,21 @@
+module Fog
+    module AzureRM
+        class CustomAzureOperationError < MsRestAzure::AzureOperationError
+            
+            def initialize(message, azure_exception)
+                super("Exception in #{message}")
+                @request = azure_exception.request.clone
+                @response = azure_exception.response.clone
+            end
+        end
+
+        class CustomAzureCoreHttpError < Azure::Core::Http::HTTPError
+
+            def initialize (description, azure_exception)
+                super("Exception in #{description}")
+                @request = azure_exception.request.clone
+                @response = azure_exception.response.clone
+            end
+        end
+    end
+end

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -49,11 +49,12 @@ def get_record_type(type)
 end
 
 def raise_azure_exception(exception, msg)
-  case exception
-  when exception.is_a?(Azure::Core::Http::HTTPError)
+  if exception.is_a?(Azure::Core::Http::HTTPError)
     raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception)
-  when exception.is_a?(MsRestAzure::AzureOperationError)
+  elsif exception.is_a?(MsRestAzure::AzureOperationError)
     raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
+  else
+    raise exception
   end
 end
 

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -49,13 +49,9 @@ def get_record_type(type)
 end
 
 def raise_azure_exception(exception, msg)
-  if exception.is_a?(Azure::Core::Http::HTTPError)
-    raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception)
-  elsif exception.is_a?(MsRestAzure::AzureOperationError)
-    raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
-  else
-    raise exception
-  end
+  raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception) if exception.is_a?(Azure::Core::Http::HTTPError)
+  raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception) if exception.is_a?(MsRestAzure::AzureOperationError)
+  raise exception
 end
 
 # Make sure if input_params(Hash) contains all keys present in required_params(Array)

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../custom_fog_errors.rb', __FILE__)
+
 # Pick Resource Group name from Azure Resource Id(String)
 def get_resource_group_from_id(id)
   id.split('/')[4]
@@ -47,11 +49,12 @@ def get_record_type(type)
 end
 
 def raise_azure_exception(exception, msg)
-  description = exception.is_a?(Azure::Core::Http::HTTPError) ? exception.description : exception.error_message
-  exception_message = "Exception in #{msg} #{description} Type: #{exception.class}\n#{exception.backtrace.join('\n')}"
-
-  Fog::Logger.debug exception.backtrace
-  raise exception_message
+  case
+  when exception.is_a?(Azure::Core::Http::HTTPError)
+    raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception)
+  when exception.is_a?(MsRestAzure::AzureOperationError) 
+    raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
+  end
 end
 
 # Make sure if input_params(Hash) contains all keys present in required_params(Array)

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -49,10 +49,10 @@ def get_record_type(type)
 end
 
 def raise_azure_exception(exception, msg)
-  case
+  case exception
   when exception.is_a?(Azure::Core::Http::HTTPError)
     raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception)
-  when exception.is_a?(MsRestAzure::AzureOperationError) 
+  when exception.is_a?(MsRestAzure::AzureOperationError)
     raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
   end
 end

--- a/test/requests/application_gateway/test_check_ag_exists.rb
+++ b/test/requests/application_gateway/test_check_ag_exists.rb
@@ -32,7 +32,7 @@ class TestCheckAGExists < Minitest::Test
   def test_check_app_gateway_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_ag_exists('fog-test-rg', 'fogRM-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_ag_exists('fog-test-rg', 'fogRM-rg') }
     end
   end
 end

--- a/test/requests/application_gateway/test_create_or_update_application_gateway.rb
+++ b/test/requests/application_gateway/test_create_or_update_application_gateway.rb
@@ -27,7 +27,7 @@ class TestCreateOrUpdateApplicationGateway < Minitest::Test
   def test_create_or_update_application_gateway_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_application_gateway(@gateway_params)
       end
     end

--- a/test/requests/application_gateway/test_delete_application_gateway.rb
+++ b/test/requests/application_gateway/test_delete_application_gateway.rb
@@ -17,7 +17,7 @@ class TestDeleteApplicationGateway < Minitest::Test
   def test_delete_application_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_application_gateway('fogRM-rg', 'gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_application_gateway('fogRM-rg', 'gateway') }
     end
   end
 end

--- a/test/requests/application_gateway/test_get_application_gateway.rb
+++ b/test/requests/application_gateway/test_get_application_gateway.rb
@@ -18,7 +18,7 @@ class TestGetApplicationGateway < Minitest::Test
   def test_get_application_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_application_gateway('fog-test-rg', 'fogRM-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_application_gateway('fog-test-rg', 'fogRM-rg') }
     end
   end
 end

--- a/test/requests/application_gateway/test_list_application_gateways.rb
+++ b/test/requests/application_gateway/test_list_application_gateways.rb
@@ -18,7 +18,7 @@ class TestListApplicationGateways < Minitest::Test
   def test_list_application_gateways_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_application_gateways('fogRM-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_application_gateways('fogRM-rg') }
     end
   end
 end

--- a/test/requests/application_gateway/test_start_application_gateway.rb
+++ b/test/requests/application_gateway/test_start_application_gateway.rb
@@ -17,7 +17,7 @@ class TestStartApplicationGateway < Minitest::Test
   def test_start_application_gateway_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :start, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.start_application_gateway('test-rg', 'test-ag')
       end
     end

--- a/test/requests/application_gateway/test_stop_application_gateway.rb
+++ b/test/requests/application_gateway/test_stop_application_gateway.rb
@@ -17,7 +17,7 @@ class TestStopApplicationGateway < Minitest::Test
   def test_stop_application_gateway_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateways.stub :stop, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.stop_application_gateway('test-rg', 'test-ag')
       end
     end

--- a/test/requests/compute/test_attach_data_disk_to_vm.rb
+++ b/test/requests/compute/test_attach_data_disk_to_vm.rb
@@ -62,7 +62,7 @@ class TestAttachDataDiskToVM < Minitest::Test
     @virtual_machines.stub :get, @get_vm_response do
       @storage_accounts.stub :list_keys, @storage_access_keys_response do
         @virtual_machines.stub :create_or_update, update_vm_response do
-          assert_raises RuntimeError do
+          assert_raises Azure::Core::Http::HTTPError do
             @service.attach_data_disk_to_vm(@input_params, false)
           end
         end
@@ -75,7 +75,7 @@ class TestAttachDataDiskToVM < Minitest::Test
     @virtual_machines.stub :get, @get_vm_response do
       @storage_accounts.stub :list_keys, @storage_access_keys_response do
         @virtual_machines.stub :create_or_update, update_vm_response do
-          assert_raises RuntimeError do
+          assert_raises Azure::Core::Http::HTTPError do
             @service.attach_data_disk_to_vm(@input_params, false)
           end
         end
@@ -86,7 +86,7 @@ class TestAttachDataDiskToVM < Minitest::Test
   def test_get_vm_failure
     get_vm_response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :get, get_vm_response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.attach_data_disk_to_vm(@input_params, false)
       end
     end
@@ -96,7 +96,7 @@ class TestAttachDataDiskToVM < Minitest::Test
     storage_access_keys_response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :get, @get_vm_response do
       @storage_accounts.stub :list_keys, storage_access_keys_response do
-        assert_raises RuntimeError do
+        assert_raises MsRestAzure::AzureOperationError do
           @service.attach_data_disk_to_vm(@input_params, false)
         end
       end

--- a/test/requests/compute/test_check_availability_set_exists.rb
+++ b/test/requests/compute/test_check_availability_set_exists.rb
@@ -32,7 +32,7 @@ class TestCheckAvailabilitySetExists < Minitest::Test
   def test_check_availability_set_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @availability_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_availability_set_exists('myrg1', 'myavset1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_availability_set_exists('myrg1', 'myavset1') }
     end
   end
 end

--- a/test/requests/compute/test_check_managed_disk_exists.rb
+++ b/test/requests/compute/test_check_managed_disk_exists.rb
@@ -32,7 +32,7 @@ class TestCheckManagedDiskExists < Minitest::Test
   def test_check_managed_disk_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @managed_disks.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_managed_disk_exists('myrg1', 'mydisk1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_managed_disk_exists('myrg1', 'mydisk1') }
     end
   end
 end

--- a/test/requests/compute/test_check_vm_exists.rb
+++ b/test/requests/compute/test_check_vm_exists.rb
@@ -32,7 +32,7 @@ class TestCheckVirtualMachineExists < Minitest::Test
   def test_check_vm_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @virtual_machines.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_exists('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vm_exists('fog-test-rg', 'fog-test-server', false) }
     end
   end
 end

--- a/test/requests/compute/test_check_vm_extension_exists.rb
+++ b/test/requests/compute/test_check_vm_extension_exists.rb
@@ -32,7 +32,7 @@ class TestCheckVMExtensionExists < Minitest::Test
   def test_check_vm_extension_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @vm_extension.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vm_extension_exists('fog-test-rg', 'fog-test-vm', 'fog-test-extension') }
     end
   end
 end

--- a/test/requests/compute/test_create_availability_set.rb
+++ b/test/requests/compute/test_create_availability_set.rb
@@ -71,7 +71,7 @@ class TestCreateAvailabilitySet < Minitest::Test
 
     @availability_sets.stub :validate_params, true do
       @availability_sets.stub :create_or_update, response do
-        assert_raises(RuntimeError) { @service.create_availability_set(avail_set_params) }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.create_availability_set(avail_set_params) }
       end
     end
   end
@@ -105,7 +105,7 @@ class TestCreateAvailabilitySet < Minitest::Test
 
     @availability_sets.stub :validate_params, true do
       @availability_sets.stub :create_or_update, response do
-        assert_raises(RuntimeError) { @service.create_availability_set(avail_set_params) }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.create_availability_set(avail_set_params) }
       end
     end
   end

--- a/test/requests/compute/test_create_image.rb
+++ b/test/requests/compute/test_create_image.rb
@@ -19,7 +19,7 @@ class TestCreateImage < Minitest::Test
   def test_create_image_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @image.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_image(@input_params)
       end
     end

--- a/test/requests/compute/test_create_or_update_managed_disk.rb
+++ b/test/requests/compute/test_create_or_update_managed_disk.rb
@@ -31,7 +31,7 @@ class TestCreateManagedDisk < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :validate_params, true do
       @managed_disks.stub :create_or_update, response do
-        assert_raises(RuntimeError) { @service.create_or_update_managed_disk(@disk) }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_managed_disk(@disk) }
       end
     end
   end

--- a/test/requests/compute/test_create_virtual_machine.rb
+++ b/test/requests/compute/test_create_virtual_machine.rb
@@ -96,7 +96,7 @@ class TestCreateVirtualMachine < Minitest::Test
   def test_create_virtual_machine_failure
     @virtual_machines.stub :create_or_update, @error_response do
       @virtual_machines.stub :get, @error_response do
-        assert_raises RuntimeError do
+        assert_raises MsRestAzure::AzureOperationError do
           @service.create_virtual_machine(@linux_virtual_machine_hash)
         end
       end
@@ -105,7 +105,7 @@ class TestCreateVirtualMachine < Minitest::Test
     # Async
     @virtual_machines.stub :create_or_update_async, @error_response do
       @virtual_machines.stub :get, @error_response do
-        assert_raises RuntimeError do
+        assert_raises MsRestAzure::AzureOperationError do
           @service.create_virtual_machine(@linux_virtual_machine_hash, true)
         end
       end

--- a/test/requests/compute/test_create_vm_extension.rb
+++ b/test/requests/compute/test_create_vm_extension.rb
@@ -27,7 +27,7 @@ class TestCreateVMExtension < Minitest::Test
   def test_create_vm_extension_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vm_extension.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_vm_extension(@vm_extension_params)
       end
     end

--- a/test/requests/compute/test_deallocate_virtual_machine.rb
+++ b/test/requests/compute/test_deallocate_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestDeallocateVirtualMachine < Minitest::Test
   def test_deallocate_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :deallocate, response do
-      assert_raises(RuntimeError) { @service.deallocate_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.deallocate_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :deallocate_async, response do
-      assert_raises(RuntimeError) { @service.deallocate_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.deallocate_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_delete_availability_set.rb
+++ b/test/requests/compute/test_delete_availability_set.rb
@@ -17,7 +17,7 @@ class TestDeleteAvailabilitySet < Minitest::Test
   def test_delete_availability_set_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @availability_sets.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_availability_set('fog-test-rg', 'fog-test-as') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_availability_set('fog-test-rg', 'fog-test-as') }
     end
   end
 end

--- a/test/requests/compute/test_delete_image.rb
+++ b/test/requests/compute/test_delete_image.rb
@@ -17,7 +17,7 @@ class TestDeleteImage < Minitest::Test
   def test_delete_image_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @image.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_image('fog-test-rg', 'fog-test-server-osImage') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_image('fog-test-rg', 'fog-test-server-osImage') }
     end
   end
 end

--- a/test/requests/compute/test_delete_managed_disk.rb
+++ b/test/requests/compute/test_delete_managed_disk.rb
@@ -17,7 +17,7 @@ class TestDeleteManagedDisk < Minitest::Test
   def test_delete_managed_disk_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_managed_disk('fog-test-rg', 'test-disk') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_managed_disk('fog-test-rg', 'test-disk') }
     end
   end
 end

--- a/test/requests/compute/test_delete_virtual_machine.rb
+++ b/test/requests/compute/test_delete_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestDeleteVirtualMachine < Minitest::Test
   def test_delete_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :delete_async, response do
-      assert_raises(RuntimeError) { @service.delete_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_detach_data_disk_from_vm.rb
+++ b/test/requests/compute/test_detach_data_disk_from_vm.rb
@@ -23,7 +23,7 @@ class TestDetachDataDiskFromVM < Minitest::Test
     update_vm_response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :get, get_vm_response do
       @virtual_machines.stub :create_or_update, update_vm_response do
-        assert_raises RuntimeError do
+        assert_raises MsRestAzure::AzureOperationError do
           @service.detach_data_disk_from_vm('fog-test-rg', 'fog-test-vm', 'mydatadisk1', false)
         end
       end

--- a/test/requests/compute/test_generalize_virtual_machine.rb
+++ b/test/requests/compute/test_generalize_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestGeneralizeVirtualMachine < Minitest::Test
   def test_generalize_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :generalize, response do
-      assert_raises(RuntimeError) { @service.generalize_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.generalize_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :generalize_async, response do
-      assert_raises(RuntimeError) { @service.generalize_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.generalize_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_get_availability_set.rb
+++ b/test/requests/compute/test_get_availability_set.rb
@@ -18,7 +18,7 @@ class TestGetAvailabilitySet < Minitest::Test
   def test_list_availability_set_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @availability_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_availability_set('myrg1', 'myavset1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_availability_set('myrg1', 'myavset1') }
     end
   end
 end

--- a/test/requests/compute/test_get_image.rb
+++ b/test/requests/compute/test_get_image.rb
@@ -17,7 +17,7 @@ class TestGetImage < Minitest::Test
   def test_get_image_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @image.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_image('fog-test-rg', 'TestImage') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_image('fog-test-rg', 'TestImage') }
     end
   end
 end

--- a/test/requests/compute/test_get_managed_disk.rb
+++ b/test/requests/compute/test_get_managed_disk.rb
@@ -18,7 +18,7 @@ class TestGetManagedDisk < Minitest::Test
   def test_get_managed_disk_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_managed_disk('myrg1', 'disk1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_managed_disk('myrg1', 'disk1') }
     end
   end
 end

--- a/test/requests/compute/test_get_virtual_machine.rb
+++ b/test/requests/compute/test_get_virtual_machine.rb
@@ -18,7 +18,7 @@ class TestGetVirtualMachine < Minitest::Test
   def test_get_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
   end
 end

--- a/test/requests/compute/test_get_vm_extension.rb
+++ b/test/requests/compute/test_get_vm_extension.rb
@@ -18,7 +18,7 @@ class TestGetVMExtension < Minitest::Test
   def test_update_vm_extension_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vm_extension.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_vm_extension('fog-test-rg', 'fog-test-vm', 'fog-test-extension')
       end
     end

--- a/test/requests/compute/test_get_vm_status.rb
+++ b/test/requests/compute/test_get_vm_status.rb
@@ -19,7 +19,7 @@ class TestGetVirtualMachineStatus < Minitest::Test
   def test_vm_status_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vm_status('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vm_status('fog-test-rg', 'fog-test-server', false) }
     end
   end
 end

--- a/test/requests/compute/test_grant_access_to_managed_disk.rb
+++ b/test/requests/compute/test_grant_access_to_managed_disk.rb
@@ -20,7 +20,7 @@ class TestGrantAccessToManagedDisk < Minitest::Test
   def test_grant_access_to_managed_disk_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :grant_access, response do
-      assert_raises(RuntimeError) { @service.grant_access_to_managed_disk('myrg1', 'disk1', 'Read', 100) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.grant_access_to_managed_disk('myrg1', 'disk1', 'Read', 100) }
     end
   end
 end

--- a/test/requests/compute/test_list_availability_sets.rb
+++ b/test/requests/compute/test_list_availability_sets.rb
@@ -18,7 +18,7 @@ class TestListAvailabilitySet < Minitest::Test
   def test_list_availability_set_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @availability_sets.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_availability_sets('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_availability_sets('fog-test-rg') }
     end
   end
 end

--- a/test/requests/compute/test_list_available_sizes_for_virtual_machine.rb
+++ b/test/requests/compute/test_list_available_sizes_for_virtual_machine.rb
@@ -23,11 +23,11 @@ class TestListAvailableSizesForVirtualMachine < Minitest::Test
   def test_list_available_sizes_for_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :list_available_sizes, response do
-      assert_raises(RuntimeError) { @service.list_available_sizes_for_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_available_sizes_for_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :list_available_sizes_async, response do
-      assert_raises(RuntimeError) { @service.list_available_sizes_for_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_available_sizes_for_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_list_managed_disks_by_rg.rb
+++ b/test/requests/compute/test_list_managed_disks_by_rg.rb
@@ -18,7 +18,7 @@ class TestListManagedDisksByRG < Minitest::Test
   def test_list_managed_disks_by_rg_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :list_by_resource_group, response do
-      assert_raises(RuntimeError) { @service.list_managed_disks_by_rg('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_managed_disks_by_rg('fog-test-rg') }
     end
   end
 end

--- a/test/requests/compute/test_list_managed_disks_in_subscription.rb
+++ b/test/requests/compute/test_list_managed_disks_in_subscription.rb
@@ -18,7 +18,7 @@ class TestListManagedDisksInSubscription < Minitest::Test
   def test_list_managed_disks_in_subscription_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_managed_disks_in_subscription }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_managed_disks_in_subscription }
     end
   end
 end

--- a/test/requests/compute/test_list_virtual_machines.rb
+++ b/test/requests/compute/test_list_virtual_machines.rb
@@ -18,7 +18,7 @@ class TestListVirtualMachines < Minitest::Test
   def test_list_virtual_machines_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_virtual_machines('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_virtual_machines('fog-test-rg') }
     end
   end
 end

--- a/test/requests/compute/test_power_off_virtual_machine.rb
+++ b/test/requests/compute/test_power_off_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestPowerOffVirtualMachine < Minitest::Test
   def test_power_off_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :power_off, response do
-      assert_raises(RuntimeError) { @service.power_off_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.power_off_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :power_off_async, response do
-      assert_raises(RuntimeError) { @service.power_off_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.power_off_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_redeploy_virtual_machine.rb
+++ b/test/requests/compute/test_redeploy_virtual_machine.rb
@@ -22,12 +22,12 @@ class TestRedeployVirtualMachine < Minitest::Test
   def test_redeploy_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :redeploy, response do
-      assert_raises(RuntimeError) { @service.redeploy_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.redeploy_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     async_response = Concurrent::Promise.execute { 10 }
     @virtual_machines.stub :redeploy_async, response do
-      assert_raises(RuntimeError) { @service.redeploy_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.redeploy_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_restart_virtual_machine.rb
+++ b/test/requests/compute/test_restart_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestRestartVirtualMachine < Minitest::Test
   def test_restart_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :restart, response do
-      assert_raises(RuntimeError) { @service.restart_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.restart_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :restart_async, response do
-      assert_raises(RuntimeError) { @service.restart_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.restart_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_revoke_access_to_managed_disk.rb
+++ b/test/requests/compute/test_revoke_access_to_managed_disk.rb
@@ -18,7 +18,7 @@ class TestRevokeAccessFromManagedDisk < Minitest::Test
   def test_revoke_access_from_managed_disk_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @managed_disks.stub :revoke_access, response do
-      assert_raises(RuntimeError) { @service.revoke_access_to_managed_disk('myrg1', 'myavset1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.revoke_access_to_managed_disk('myrg1', 'myavset1') }
     end
   end
 end

--- a/test/requests/compute/test_start_virtual_machine.rb
+++ b/test/requests/compute/test_start_virtual_machine.rb
@@ -22,11 +22,11 @@ class TestStartVirtualMachine < Minitest::Test
   def test_start_virtual_machine_failure
     response = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_machines.stub :start, response do
-      assert_raises(RuntimeError) { @service.start_virtual_machine('fog-test-rg', 'fog-test-server', false) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.start_virtual_machine('fog-test-rg', 'fog-test-server', false) }
     end
 
     @virtual_machines.stub :start_async, response do
-      assert_raises(RuntimeError) { @service.start_virtual_machine('fog-test-rg', 'fog-test-server', true) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.start_virtual_machine('fog-test-rg', 'fog-test-server', true) }
     end
   end
 end

--- a/test/requests/compute/test_update_vm_extension.rb
+++ b/test/requests/compute/test_update_vm_extension.rb
@@ -27,7 +27,7 @@ class TestUpdateVMExtension < Minitest::Test
   def test_update_vm_extension_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vm_extension.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_vm_extension(@vm_extension_hash)
       end
     end

--- a/test/requests/dns/test_check_record_set_exists.rb
+++ b/test/requests/dns/test_check_record_set_exists.rb
@@ -32,7 +32,7 @@ class TestCheckRecordSetExists < Minitest::Test
   def test_check_record_set_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @record_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_record_set_exists('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
     end
   end
 end

--- a/test/requests/dns/test_check_zone_exists.rb
+++ b/test/requests/dns/test_check_zone_exists.rb
@@ -41,7 +41,7 @@ class TestCheckZoneExists < Minitest::Test
   def test_check_zone_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @zones.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.check_zone_exists('fog-test-rg', 'zone_name')
       end
     end

--- a/test/requests/dns/test_create_record_set.rb
+++ b/test/requests/dns/test_create_record_set.rb
@@ -38,7 +38,7 @@ class TestCreateRecordSet < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     record_set_params = { records: %w(1.2.3.4 1.2.3.3) }
     @record_sets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_record_set(record_set_params, 'CNAME')
       end
     end

--- a/test/requests/dns/test_create_zone.rb
+++ b/test/requests/dns/test_create_zone.rb
@@ -29,7 +29,7 @@ class TestCreateZone < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     zone_params = {}
     @zones.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_zone(zone_params)
       end
     end

--- a/test/requests/dns/test_delete_record_set.rb
+++ b/test/requests/dns/test_delete_record_set.rb
@@ -18,7 +18,7 @@ class TestDeleteRecordSet < Minitest::Test
   def test_delete_record_set_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @record_sets.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_record_set('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', '') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_record_set('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', '') }
     end
   end
 end

--- a/test/requests/dns/test_delete_zone.rb
+++ b/test/requests/dns/test_delete_zone.rb
@@ -18,7 +18,7 @@ class TestDeleteZone < Minitest::Test
   def test_delete_zone_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @zones.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_zone('fog-test-rg', 'fog-test-zone') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_zone('fog-test-rg', 'fog-test-zone') }
     end
   end
 end

--- a/test/requests/dns/test_get_record_set.rb
+++ b/test/requests/dns/test_get_record_set.rb
@@ -18,7 +18,7 @@ class TestGetRecordSet < Minitest::Test
   def test_get_record_set_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @record_sets.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_record_set('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_record_set('fog-test-rg', 'fog-test-result', 'fog-test-zone', 'CNAME') }
     end
   end
 end

--- a/test/requests/dns/test_get_records_from_record_set.rb
+++ b/test/requests/dns/test_get_records_from_record_set.rb
@@ -34,7 +34,7 @@ class TestGetRecordsFromRecordSet < Minitest::Test
   def test_get_records_from_record_set_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @record_sets.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_records_from_record_set('fog-test-rg', 'fog-test-record-set', 'fog-test-zone', 'CNAME')
       end
     end

--- a/test/requests/dns/test_get_zone.rb
+++ b/test/requests/dns/test_get_zone.rb
@@ -27,7 +27,7 @@ class TestGetZone < Minitest::Test
   def test_get_zone_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @zones.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_zone('fog-test-rg', 'zone_name')
       end
     end

--- a/test/requests/dns/test_list_record_sets.rb
+++ b/test/requests/dns/test_list_record_sets.rb
@@ -27,7 +27,7 @@ class TestListRecordSets < Minitest::Test
   def test_list_record_sets_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @record_sets.stub :list_by_dns_zone, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.list_record_sets('fog-test-rg', 'fog-test-zone')
       end
     end

--- a/test/requests/dns/test_list_zones.rb
+++ b/test/requests/dns/test_list_zones.rb
@@ -18,7 +18,7 @@ class TestListZones < Minitest::Test
   def test_list_zones_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @zones.stub :list, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.list_zones
       end
     end

--- a/test/requests/key_vault/test_check_vault_exists.rb
+++ b/test/requests/key_vault/test_check_vault_exists.rb
@@ -32,7 +32,7 @@ class TestCheckVaultExists < Minitest::Test
   def test_check_vault_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @vaults.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vault_exists('fog-test-rg', 'fog-test-kv') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vault_exists('fog-test-rg', 'fog-test-kv') }
     end
   end
 end

--- a/test/requests/key_vault/test_create_or_update_vault.rb
+++ b/test/requests/key_vault/test_create_or_update_vault.rb
@@ -19,7 +19,7 @@ class TestCreateOrUpdateVault < Minitest::Test
   def test_create_vault_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vaults.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_or_update_vault(name: 'fog-test-kv') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_vault(name: 'fog-test-kv') }
     end
   end
 end

--- a/test/requests/key_vault/test_delete_vault.rb
+++ b/test/requests/key_vault/test_delete_vault.rb
@@ -17,7 +17,7 @@ class TestDeleteVault < Minitest::Test
   def test_delete_vault_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vaults.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_vault('fog-test-rg', 'fog-test-kv') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_vault('fog-test-rg', 'fog-test-kv') }
     end
   end
 end

--- a/test/requests/key_vault/test_get_vault.rb
+++ b/test/requests/key_vault/test_get_vault.rb
@@ -18,7 +18,7 @@ class TestGetVault < Minitest::Test
   def test_get_vault_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vaults.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_vault('fog-test-rg', 'fog-test-kv') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_vault('fog-test-rg', 'fog-test-kv') }
     end
   end
 end

--- a/test/requests/key_vault/test_list_vaults.rb
+++ b/test/requests/key_vault/test_list_vaults.rb
@@ -18,7 +18,7 @@ class TestListVaults < Minitest::Test
   def test_list_vaults_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @vaults.stub :list_by_resource_group_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_vaults('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_vaults('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_add_address_prefixes_in_virtual_network.rb
+++ b/test/requests/network/test_add_address_prefixes_in_virtual_network.rb
@@ -21,7 +21,7 @@ class TestAddAddressPrefixesInVirtualNetwork < Minitest::Test
   def test_add_address_prefixes_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.add_address_prefixes_in_virtual_network('fog-test-rg', 'fog-test-virtual-network', ['10.1.0.0/16', '10.2.0.0/16'])
       end
     end

--- a/test/requests/network/test_add_dns_servers_in_virtual_network.rb
+++ b/test/requests/network/test_add_dns_servers_in_virtual_network.rb
@@ -21,7 +21,7 @@ class TestAddDnsServersInVirtualNetwork < Minitest::Test
   def test_add_dns_servers_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.add_dns_servers_in_virtual_network('fog-test-rg', 'fog-test-virtual-network', ['10.1.0.7', '10.1.0.8'])
       end
     end

--- a/test/requests/network/test_add_subnets_in_virtual_network.rb
+++ b/test/requests/network/test_add_subnets_in_virtual_network.rb
@@ -21,7 +21,7 @@ class TestAddSubnetsInVirtualNetwork < Minitest::Test
   def test_add_subnets_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.add_subnets_in_virtual_network('fog-test-rg', 'fog-test-virtual-network', @subnets)
       end
     end

--- a/test/requests/network/test_attach_network_security_group_to_subnet.rb
+++ b/test/requests/network/test_attach_network_security_group_to_subnet.rb
@@ -18,7 +18,7 @@ class TestAttachNetworkSecurityGroupToSubnet < Minitest::Test
   def test_attach_network_security_group_to_subnet_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.attach_network_security_group_to_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network', '10.1.0.0/24', 'myNSG1', 'myRT1')
       end
     end

--- a/test/requests/network/test_attach_resource_to_nic.rb
+++ b/test/requests/network/test_attach_resource_to_nic.rb
@@ -37,7 +37,7 @@ class TestAttachResourceToNIC < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
 
     @network_interfaces.stub :get, response do
-      assert_raises(RuntimeError) { @service.attach_resource_to_nic('fog-test-rg', 'fog-test-network-interface', 'Network-Security-Group', '/subscriptions/{guid}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/myNSG1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.attach_resource_to_nic('fog-test-rg', 'fog-test-network-interface', 'Network-Security-Group', '/subscriptions/{guid}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/myNSG1') }
     end
   end
 end

--- a/test/requests/network/test_attach_route_table_to_subnet.rb
+++ b/test/requests/network/test_attach_route_table_to_subnet.rb
@@ -18,7 +18,7 @@ class TestAttachRouteTableToSubnet < Minitest::Test
   def test_attach_route_table_to_subnet_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.attach_route_table_to_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network', '10.1.0.0/24', 'myNSG1', 'myRT1')
       end
     end

--- a/test/requests/network/test_check_express_route_cir_auth_exists.rb
+++ b/test/requests/network/test_check_express_route_cir_auth_exists.rb
@@ -32,7 +32,7 @@ class TestCheckExpressRouteCirAuthExists < Minitest::Test
   def test_check_express_route_cir_auth_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @circuit_authorization.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_express_route_cir_auth_exists('Fog-rg', 'testCircuit', 'auth-name') }
     end
   end
 end

--- a/test/requests/network/test_check_express_route_circuit_exists.rb
+++ b/test/requests/network/test_check_express_route_circuit_exists.rb
@@ -32,7 +32,7 @@ class TestCheckExpressRouteCircuitExists < Minitest::Test
   def test_check_express_route_circuit_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @circuit.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_express_route_circuit_exists('fog-test-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_check_load_balancer_exists.rb
+++ b/test/requests/network/test_check_load_balancer_exists.rb
@@ -32,7 +32,7 @@ class TestCheckLoadBalancerExists < Minitest::Test
   def test_check_load_balancer_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @load_balancers.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_load_balancer_exists('fog-test-rg', 'mylb1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_load_balancer_exists('fog-test-rg', 'mylb1') }
     end
   end
 end

--- a/test/requests/network/test_check_local_net_gateway_exists.rb
+++ b/test/requests/network/test_check_local_net_gateway_exists.rb
@@ -32,7 +32,7 @@ class TestCheckLocalNetworkGatewayExists < Minitest::Test
   def test_check_local_net_gateway_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @local_network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_local_net_gateway_exists('fog-test-rg', 'fog-test-local-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_group_exists.rb
+++ b/test/requests/network/test_check_net_sec_group_exists.rb
@@ -32,7 +32,7 @@ class TestCheckNetworkSecurityGroupExists < Minitest::Test
   def test_check_net_sec_group_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @network_security_groups.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_net_sec_group_exists('fog-test-rg', 'fog-test-nsg') }
     end
   end
 end

--- a/test/requests/network/test_check_net_sec_rule_exists.rb
+++ b/test/requests/network/test_check_net_sec_rule_exists.rb
@@ -32,7 +32,7 @@ class TestCheckNetworkSecurityRuleExists < Minitest::Test
   def test_check_net_sec_rule_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @network_security_rules.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_net_sec_rule_exists('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr') }
     end
   end
 end

--- a/test/requests/network/test_check_network_interface_exists.rb
+++ b/test/requests/network/test_check_network_interface_exists.rb
@@ -32,7 +32,7 @@ class TestCheckNetworkInterfaceExists < Minitest::Test
   def test_check_network_interface_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @network_interfaces.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_network_interface_exists('fog-test-rg', 'fog-test-network-interface') }
     end
   end
 end

--- a/test/requests/network/test_check_public_ip_exists.rb
+++ b/test/requests/network/test_check_public_ip_exists.rb
@@ -31,7 +31,7 @@ class TestCheckPublicIpExists < Minitest::Test
   def test_check_public_ip_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @public_ips.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_public_ip_exists('fog-test-rg', 'fog-test-public-ip') }
     end
   end
 end

--- a/test/requests/network/test_check_subnet_exists.rb
+++ b/test/requests/network/test_check_subnet_exists.rb
@@ -32,7 +32,7 @@ class TestCheckSubnetExists < Minitest::Test
   def test_check_subnet_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @subnets.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_subnet_exists('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet') }
     end
   end
 end

--- a/test/requests/network/test_check_virtual_network_exists.rb
+++ b/test/requests/network/test_check_virtual_network_exists.rb
@@ -34,7 +34,7 @@ class TestCheckVirtualNetworkExists < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
 
     @virtual_networks.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_virtual_network_exists('fog-test-rg', 'fog-test-virtual-network') }
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_connection_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_connection_exists.rb
@@ -32,7 +32,7 @@ class TestCheckVirtualNetworkGatewayConnectionExists < Minitest::Test
   def test_check_vnet_gateway_connection_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @gateway_connections.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vnet_gateway_connection_exists('fog-test-rg', 'fog-test-gateway-connection') }
     end
   end
 end

--- a/test/requests/network/test_check_vnet_gateway_exists.rb
+++ b/test/requests/network/test_check_vnet_gateway_exists.rb
@@ -32,7 +32,7 @@ class TestCheckVirtualNetworkGatewayExists < Minitest::Test
   def test_check_vnet_gateway_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_vnet_gateway_exists('fog-test-rg', 'fog-test-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_create_express_route_circuit.rb
+++ b/test/requests/network/test_create_express_route_circuit.rb
@@ -31,7 +31,7 @@ class TestCreateExpressRouteCircuit < Minitest::Test
     peerings = ApiStub::Requests::Network::ExpressRouteCircuit.peerings
     express_route_circuit_parameters = { peerings: peerings }
     @circuit.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_express_route_circuit(express_route_circuit_parameters)
       end
     end

--- a/test/requests/network/test_create_express_route_circuit_authorization.rb
+++ b/test/requests/network/test_create_express_route_circuit_authorization.rb
@@ -27,7 +27,7 @@ class TestCreateExpressRouteCircuitAuthorization < Minitest::Test
   def test_create_express_route_circuit_authorization_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_authorizations.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_express_route_circuit_authorization(@auth_params)
       end
     end

--- a/test/requests/network/test_create_express_route_circuit_peering.rb
+++ b/test/requests/network/test_create_express_route_circuit_peering.rb
@@ -29,7 +29,7 @@ class TestCreateExpressRouteCircuitPeering < Minitest::Test
     circuit_peering_parameters = { peering_type: 'AzurePrivatePeering' }
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_peerings.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_express_route_circuit_peering(circuit_peering_parameters)
       end
     end

--- a/test/requests/network/test_create_load_balancer.rb
+++ b/test/requests/network/test_create_load_balancer.rb
@@ -42,7 +42,7 @@ class TestCreateLoadBalancer < Minitest::Test
     inbound_nat_rule = ApiStub::Requests::Network::LoadBalancer.inbound_nat_rule
     inbound_nat_pool = ApiStub::Requests::Network::LoadBalancer.inbound_nat_pool
     @load_balancers.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_load_balancer('mylb1', 'North US', 'testRG', frontend_ip_config, backend_address_pool, load_balancing_rule, probe, inbound_nat_rule, inbound_nat_pool, @tags)
       end
     end

--- a/test/requests/network/test_create_local_network_gateway.rb
+++ b/test/requests/network/test_create_local_network_gateway.rb
@@ -28,7 +28,7 @@ class TestCreateLocalNetworkGateway < Minitest::Test
     local_network_gateway_parms = { name: 'temp', resource_group: 'Test' }
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @local_network_gateways.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_local_network_gateway(local_network_gateway_parms)
       end
     end

--- a/test/requests/network/test_create_network_interface.rb
+++ b/test/requests/network/test_create_network_interface.rb
@@ -35,7 +35,7 @@ class TestCreateNetworkInterface < Minitest::Test
   def test_create_network_interface_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_interfaces.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags)
       end
     end

--- a/test/requests/network/test_create_or_update_network_security_group.rb
+++ b/test/requests/network/test_create_or_update_network_security_group.rb
@@ -31,7 +31,7 @@ class TestCreateOrUpdateNetworkSecurityGroup < Minitest::Test
   def test_create_or_update_network_security_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_groups.stub :begin_create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_network_security_group('fog-test-rg', 'fog-test-nsg', 'West US', [], @tags)
       end
     end

--- a/test/requests/network/test_create_or_update_network_security_rule.rb
+++ b/test/requests/network/test_create_or_update_network_security_rule.rb
@@ -20,7 +20,7 @@ class TestCreateOrUpdateNetworkSecurityRule < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     security_rule_params = ApiStub::Requests::Network::NetworkSecurityRule.network_security_rule_paramteres_hash
     @network_security_rules.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_network_security_rule(security_rule_params)
       end
     end

--- a/test/requests/network/test_create_or_update_virtual_network.rb
+++ b/test/requests/network/test_create_or_update_virtual_network.rb
@@ -49,7 +49,7 @@ class TestCreateOrUpdatevirtualNetwork < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
 
     @virtual_networks.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_virtual_network('fog-test-rg', 'fog-test-virtual-network', 'westus', ['10.1.0.5', '10.1.0.6'], @subnets, ['10.1.0.0/16', '10.2.0.0/16'], @tags)
       end
     end

--- a/test/requests/network/test_create_public_ip.rb
+++ b/test/requests/network/test_create_public_ip.rb
@@ -28,7 +28,7 @@ class TestCreatePublicIp < Minitest::Test
   def test_create_public_ip_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @public_ips.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_public_ip('fog-test-rg', 'fog-test-public-ip', 'West US', 'Dynamic', '', '', @tags)
       end
     end

--- a/test/requests/network/test_create_subnet.rb
+++ b/test/requests/network/test_create_subnet.rb
@@ -27,7 +27,7 @@ class TestCreateSubnet < Minitest::Test
   def test_create_subnet_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network', '10.1.0.0/24', 'nsg-id', 'table-id')
       end
     end

--- a/test/requests/network/test_create_virtual_network_gateway.rb
+++ b/test/requests/network/test_create_virtual_network_gateway.rb
@@ -29,7 +29,7 @@ class TestCreateVirtualNetworkGateway < Minitest::Test
     network_gateway_parms = {}
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_gateways.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_virtual_network_gateway(network_gateway_parms)
       end
     end

--- a/test/requests/network/test_create_virtual_network_gateway_connection.rb
+++ b/test/requests/network/test_create_virtual_network_gateway_connection.rb
@@ -28,7 +28,7 @@ class TestCreateVirtualNetworkGatewayConnection < Minitest::Test
     network_gateway_parms = { name: 'temp', resource_group_name: 'Test' }
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_virtual_network_gateway_connection(network_gateway_parms)
       end
     end

--- a/test/requests/network/test_delete_express_route_circuit.rb
+++ b/test/requests/network/test_delete_express_route_circuit.rb
@@ -18,7 +18,7 @@ class TestDeleteExpressRouteCircuit < Minitest::Test
   def test_delete_express_route_circuit_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_express_route_circuit('fogRM-rg', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_express_route_circuit('fogRM-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_delete_express_route_circuit_authorization.rb
+++ b/test/requests/network/test_delete_express_route_circuit_authorization.rb
@@ -17,7 +17,7 @@ class TestDeleteExpressRouteCircuitAuthorization < Minitest::Test
   def test_delete_express_route_circuit_authorization_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_authorization.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_express_route_circuit_authorization('Fog-rg', 'testCircuit', 'auth-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_express_route_circuit_authorization('Fog-rg', 'testCircuit', 'auth-name') }
     end
   end
 end

--- a/test/requests/network/test_delete_express_route_circuit_peering.rb
+++ b/test/requests/network/test_delete_express_route_circuit_peering.rb
@@ -18,7 +18,7 @@ class TestDeleteExpressRouteCircuitPeering < Minitest::Test
   def test_delete_express_route_circuit_peering_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_peering.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_express_route_circuit_peering('Fog-rg', 'AzurePrivatePeering', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_express_route_circuit_peering('Fog-rg', 'AzurePrivatePeering', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_delete_load_balancer.rb
+++ b/test/requests/network/test_delete_load_balancer.rb
@@ -18,7 +18,7 @@ class TestDeleteLoadBalancer < Minitest::Test
   def test_delete_load_balancer_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @load_balancers.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_load_balancer('fog-test-rg', 'fog-test-load-balancer') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_load_balancer('fog-test-rg', 'fog-test-load-balancer') }
     end
   end
 end

--- a/test/requests/network/test_delete_local_network_gateway.rb
+++ b/test/requests/network/test_delete_local_network_gateway.rb
@@ -17,7 +17,7 @@ class TestDeleteLocalNetworkGateway < Minitest::Test
   def test_delete_local_network_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @local_network_gateways.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_local_network_gateway('fog-test-rg', 'fog-test-local-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_local_network_gateway('fog-test-rg', 'fog-test-local-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_delete_network_interface.rb
+++ b/test/requests/network/test_delete_network_interface.rb
@@ -18,7 +18,7 @@ class TestDeleteNetworkInterface < Minitest::Test
   def test_delete_network_interface_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_interfaces.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_network_interface('fog-test-rg', 'fog-test-network-interface') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_network_interface('fog-test-rg', 'fog-test-network-interface') }
     end
   end
 end

--- a/test/requests/network/test_delete_network_security_group.rb
+++ b/test/requests/network/test_delete_network_security_group.rb
@@ -17,7 +17,7 @@ class TestDeleteNetworkSecurityGroup < Minitest::Test
   def test_delete_network_security_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_groups.stub :delete, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.delete_network_security_group('fog-test-rg', 'fog-test-nsg')
       end
     end

--- a/test/requests/network/test_delete_network_security_rule.rb
+++ b/test/requests/network/test_delete_network_security_rule.rb
@@ -17,7 +17,7 @@ class TestDeleteNetworkSecurityRule < Minitest::Test
   def test_delete_network_security_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_rules.stub :delete, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.delete_network_security_rule('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
       end
     end

--- a/test/requests/network/test_delete_public_ip.rb
+++ b/test/requests/network/test_delete_public_ip.rb
@@ -18,7 +18,7 @@ class TestDeletePublicIp < Minitest::Test
   def test_delete_public_ip_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @public_ips.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_public_ip('fog-test-rg', 'fog-test-public-ip') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_public_ip('fog-test-rg', 'fog-test-public-ip') }
     end
   end
 end

--- a/test/requests/network/test_delete_subnet.rb
+++ b/test/requests/network/test_delete_subnet.rb
@@ -18,7 +18,7 @@ class TestDeleteSubnet < Minitest::Test
   def test_delete_subnet_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network') }
     end
   end
 end

--- a/test/requests/network/test_delete_virtual_network.rb
+++ b/test/requests/network/test_delete_virtual_network.rb
@@ -18,7 +18,7 @@ class TestDeleteVirtualNetwork < Minitest::Test
   def test_delete_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_virtual_network('fog-test-rg', 'fog-test-virtual-network') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_virtual_network('fog-test-rg', 'fog-test-virtual-network') }
     end
   end
 end

--- a/test/requests/network/test_delete_virtual_network_gateway.rb
+++ b/test/requests/network/test_delete_virtual_network_gateway.rb
@@ -18,7 +18,7 @@ class TestDeleteVirtualNetworkGateway < Minitest::Test
   def test_delete_virtual_network_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_gateways.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_virtual_network_gateway('fog-test-rg', 'fog-test-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_virtual_network_gateway('fog-test-rg', 'fog-test-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_delete_virtual_network_gateway_connection.rb
+++ b/test/requests/network/test_delete_virtual_network_gateway_connection.rb
@@ -17,7 +17,7 @@ class TestDeleteVirtualNetworkGatewayConnection < Minitest::Test
   def test_delete_virtual_network_gateway_connection_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_virtual_network_gateway_connection('fog-test-rg', 'fog-test-gateway-connection') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_virtual_network_gateway_connection('fog-test-rg', 'fog-test-gateway-connection') }
     end
   end
 end

--- a/test/requests/network/test_detach_network_security_group_from_subnet.rb
+++ b/test/requests/network/test_detach_network_security_group_from_subnet.rb
@@ -18,7 +18,7 @@ class TestDetachNetworkSecurityGroupFromSubnet < Minitest::Test
   def test_detach_network_security_group_from_subnet_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.detach_network_security_group_from_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network', '10.1.0.0/24', 'table-id')
       end
     end

--- a/test/requests/network/test_detach_resource_from_nic.rb
+++ b/test/requests/network/test_detach_resource_from_nic.rb
@@ -33,7 +33,7 @@ class TestDetachResourceFromNIC < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
 
     @network_interfaces.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.detach_resource_from_nic('fog-test-rg', 'fog-test-network-interface', 'Network-Security-Group')
       end
     end

--- a/test/requests/network/test_detach_route_table_from_subnet.rb
+++ b/test/requests/network/test_detach_route_table_from_subnet.rb
@@ -18,7 +18,7 @@ class TestDetachRouteTableFromSubnet < Minitest::Test
   def test_detach_route_table_from_subnet_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.detach_route_table_from_subnet('fog-test-rg', 'fog-test-subnet', 'fog-test-virtual-network', '10.1.0.0/24', 'nsg-id')
       end
     end

--- a/test/requests/network/test_get_connection_shared_key.rb
+++ b/test/requests/network/test_get_connection_shared_key.rb
@@ -18,7 +18,7 @@ class TestGetConnectionSharedKey < Minitest::Test
   def test_get_connection_shared_key_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :get_shared_key, response do
-      assert_raises(RuntimeError) { @service.get_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection') }
     end
   end
 end

--- a/test/requests/network/test_get_express_route_circuit.rb
+++ b/test/requests/network/test_get_express_route_circuit.rb
@@ -18,7 +18,7 @@ class TestGetExpressRouteCircuit < Minitest::Test
   def test_get_express_route_circuit_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_express_route_circuit('fog-test-rg', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_express_route_circuit('fog-test-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_get_express_route_circuit_authorization.rb
+++ b/test/requests/network/test_get_express_route_circuit_authorization.rb
@@ -18,7 +18,7 @@ class TestGetExpressRouteCircuitAuthorization < Minitest::Test
   def test_get_express_route_circuit_authorization_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_authorization.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_express_route_circuit_authorization('Fog-rg', 'testCircuit', 'auth-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_express_route_circuit_authorization('Fog-rg', 'testCircuit', 'auth-name') }
     end
   end
 end

--- a/test/requests/network/test_get_express_route_circuit_peering.rb
+++ b/test/requests/network/test_get_express_route_circuit_peering.rb
@@ -18,7 +18,7 @@ class TestGetExpressRouteCircuitPeering < Minitest::Test
   def test_get_express_route_circuit_peering_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_peering.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_express_route_circuit_peering('Fog-rg', 'AzurePrivatePeering', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_express_route_circuit_peering('Fog-rg', 'AzurePrivatePeering', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_get_load_balancer.rb
+++ b/test/requests/network/test_get_load_balancer.rb
@@ -18,7 +18,7 @@ class TestGetLoadBalancer < Minitest::Test
   def test_get_load_balancer_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @load_balancers.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_load_balancer('fog-test-rg', 'mylb1') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_load_balancer('fog-test-rg', 'mylb1') }
     end
   end
 end

--- a/test/requests/network/test_get_local_network_gateway.rb
+++ b/test/requests/network/test_get_local_network_gateway.rb
@@ -18,7 +18,7 @@ class TestGetLocalNetworkGateway < Minitest::Test
   def test_get_local_network_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @local_network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_local_network_gateway('fog-test-rg', 'fog-test-local-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_local_network_gateway('fog-test-rg', 'fog-test-local-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_get_network_interface.rb
+++ b/test/requests/network/test_get_network_interface.rb
@@ -18,7 +18,7 @@ class TestGetNetworkInterface < Minitest::Test
   def test_get_network_interface_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_interfaces.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_network_interface('fog-test-rg', 'fog-test-network-interface') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_network_interface('fog-test-rg', 'fog-test-network-interface') }
     end
   end
 end

--- a/test/requests/network/test_get_network_security_group.rb
+++ b/test/requests/network/test_get_network_security_group.rb
@@ -18,7 +18,7 @@ class TestGetNetworkSecurityGroup < Minitest::Test
   def test_get_network_security_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_groups.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_network_security_group('fog-test-rg', 'fog-test-nsg')
       end
     end

--- a/test/requests/network/test_get_network_security_rule.rb
+++ b/test/requests/network/test_get_network_security_rule.rb
@@ -18,7 +18,7 @@ class TestGetNetworkSecurityRule < Minitest::Test
   def test_get_network_security_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_rules.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_network_security_rule('fog-test-rg', 'fog-test-nsg', 'fog-test-nsr')
       end
     end

--- a/test/requests/network/test_get_public_ip.rb
+++ b/test/requests/network/test_get_public_ip.rb
@@ -18,7 +18,7 @@ class TestGetPublicIp < Minitest::Test
   def test_get_public_ip_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @public_ips.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_public_ip('fog-test-rg', 'fog-test-public-ip')
       end
     end

--- a/test/requests/network/test_get_subnet.rb
+++ b/test/requests/network/test_get_subnet.rb
@@ -18,7 +18,7 @@ class TestGetSubnet < Minitest::Test
   def test_get_subnet_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_subnet('fog-test-rg', 'fog-test-virtual-network', 'fog-test-subnet')
       end
     end

--- a/test/requests/network/test_get_virtual_network.rb
+++ b/test/requests/network/test_get_virtual_network.rb
@@ -18,7 +18,7 @@ class TestGetVirtualNetwork < Minitest::Test
   def test_get_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.get_virtual_network('fog-test-rg', 'fog-test-virtual-network')
       end
     end

--- a/test/requests/network/test_get_virtual_network_gateway.rb
+++ b/test/requests/network/test_get_virtual_network_gateway.rb
@@ -18,7 +18,7 @@ class TestGetVirtualNetworkGateway < Minitest::Test
   def test_get_virtual_network_gateway_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_gateways.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_virtual_network_gateway('fog-test-rg', 'fog-test-network-gateway') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_virtual_network_gateway('fog-test-rg', 'fog-test-network-gateway') }
     end
   end
 end

--- a/test/requests/network/test_get_virtual_network_gateway_connection.rb
+++ b/test/requests/network/test_get_virtual_network_gateway_connection.rb
@@ -18,7 +18,7 @@ class TestGetVirtualNetworkGatewayConnection < Minitest::Test
   def test_get_virtual_network_gateway_connection_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_virtual_network_gateway_connection('fog-test-rg', 'fog-test-gateway-connection') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_virtual_network_gateway_connection('fog-test-rg', 'fog-test-gateway-connection') }
     end
   end
 end

--- a/test/requests/network/test_list_express_route_circuit_authorizations.rb
+++ b/test/requests/network/test_list_express_route_circuit_authorizations.rb
@@ -18,7 +18,7 @@ class TestListExpressRouteCircuitAuthorization < Minitest::Test
   def test_list_express_route_circuit_authorizations_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_authorization.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_express_route_circuit_authorizations('fogRM-rg', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_express_route_circuit_authorizations('fogRM-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_list_express_route_circuit_peerings.rb
+++ b/test/requests/network/test_list_express_route_circuit_peerings.rb
@@ -18,7 +18,7 @@ class TestListExpressRouteCircuitPeerings < Minitest::Test
   def test_list_express_route_circuit_peerings_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit_peering.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_express_route_circuit_peerings('fogRM-rg', 'testCircuit') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_express_route_circuit_peerings('fogRM-rg', 'testCircuit') }
     end
   end
 end

--- a/test/requests/network/test_list_express_route_circuits.rb
+++ b/test/requests/network/test_list_express_route_circuits.rb
@@ -20,7 +20,7 @@ class TestListExpressRouteCircuits < Minitest::Test
   def test_list_express_route_circuits_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @circuit.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_express_route_circuits('fogRM-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_express_route_circuits('fogRM-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_express_route_service_providers.rb
+++ b/test/requests/network/test_list_express_route_service_providers.rb
@@ -18,7 +18,7 @@ class TestListExpressServiceProviders < Minitest::Test
   def test_list_express_route_service_providers_failure
     response = -> { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @service_provider.stub :list, response do
-      assert_raises(RuntimeError) { @service.list_express_route_service_providers }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_express_route_service_providers }
     end
   end
 end

--- a/test/requests/network/test_list_load_balancers.rb
+++ b/test/requests/network/test_list_load_balancers.rb
@@ -18,7 +18,7 @@ class TestListLoadBalancers < Minitest::Test
   def test_list_load_balancers_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @load_balancers.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_load_balancers('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_load_balancers('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_local_network_gateways.rb
+++ b/test/requests/network/test_list_local_network_gateways.rb
@@ -18,7 +18,7 @@ class TestListLocalNetwrokGateways < Minitest::Test
   def test_list_local_network_gateways_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @local_network_gateways.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_local_network_gateways('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_local_network_gateways('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_network_interfaces.rb
+++ b/test/requests/network/test_list_network_interfaces.rb
@@ -18,7 +18,7 @@ class TestListNetworkInterfaces < Minitest::Test
   def test_list_network_interfaces_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_interfaces.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_network_interfaces('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_network_interfaces('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_network_security_groups.rb
+++ b/test/requests/network/test_list_network_security_groups.rb
@@ -18,7 +18,7 @@ class TestListNetworkSecurityGroup < Minitest::Test
   def test_list_network_security_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_groups.stub :list_as_lazy, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.list_network_security_groups('fog-test-rg')
       end
     end

--- a/test/requests/network/test_list_network_security_rules.rb
+++ b/test/requests/network/test_list_network_security_rules.rb
@@ -18,7 +18,7 @@ class TestListNetworkSecurityRule < Minitest::Test
   def test_list_network_security_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_security_rules.stub :list_as_lazy, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.list_network_security_rules('fog-test-rg', 'fog-test-nsg')
       end
     end

--- a/test/requests/network/test_list_public_ips.rb
+++ b/test/requests/network/test_list_public_ips.rb
@@ -18,7 +18,7 @@ class TestListPublicIps < Minitest::Test
   def test_list_public_ips_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @public_ips.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_public_ips('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_public_ips('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_subnets.rb
+++ b/test/requests/network/test_list_subnets.rb
@@ -18,7 +18,7 @@ class TestListSubnets < Minitest::Test
   def test_list_subnets_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @subnets.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_subnets('fog-test-rg', 'fog-test-virtual-network') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_subnets('fog-test-rg', 'fog-test-virtual-network') }
     end
   end
 end

--- a/test/requests/network/test_list_virtual_network_gateway_connections.rb
+++ b/test/requests/network/test_list_virtual_network_gateway_connections.rb
@@ -18,7 +18,7 @@ class TestListVirtualNetwrokGatewayConnections < Minitest::Test
   def test_list_virtual_network_gateway_connections_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_virtual_network_gateway_connections('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_virtual_network_gateway_connections('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_virtual_network_gateways.rb
+++ b/test/requests/network/test_list_virtual_network_gateways.rb
@@ -18,7 +18,7 @@ class TestListVirtualNetwrokGateways < Minitest::Test
   def test_list_virtual_network_gateways_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @network_gateways.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_virtual_network_gateways('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_virtual_network_gateways('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_virtual_networks.rb
+++ b/test/requests/network/test_list_virtual_networks.rb
@@ -18,7 +18,7 @@ class TestListVirtualNetworks < Minitest::Test
   def test_list_virtual_networks_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_virtual_networks('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_virtual_networks('fog-test-rg') }
     end
   end
 end

--- a/test/requests/network/test_list_virtual_networks_in_subscription.rb
+++ b/test/requests/network/test_list_virtual_networks_in_subscription.rb
@@ -18,7 +18,7 @@ class TestListVirtualNetworksInSubscription < Minitest::Test
   def test_list_virtual_networks_in_subscription_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :list_all, response do
-      assert_raises(RuntimeError) { @service.list_virtual_networks_in_subscription }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_virtual_networks_in_subscription }
     end
   end
 end

--- a/test/requests/network/test_remove_address_prefixes_from_virtual_network.rb
+++ b/test/requests/network/test_remove_address_prefixes_from_virtual_network.rb
@@ -21,7 +21,7 @@ class TestRemoveddressPrefixesInVirtualNetwork < Minitest::Test
   def test_remove_address_prefixes_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.remove_address_prefixes_from_virtual_network('fog-test-rg', 'fog-test-virtual-network', ['10.1.0.0/16'])
       end
     end

--- a/test/requests/network/test_remove_dns_servers_from_virtual_network.rb
+++ b/test/requests/network/test_remove_dns_servers_from_virtual_network.rb
@@ -21,7 +21,7 @@ class TestRemoveDnsServersInVirtualNetwork < Minitest::Test
   def test_remove_dns_servers_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.remove_dns_servers_from_virtual_network('fog-test-rg', 'fog-test-virtual-network', ['10.1.0.5'])
       end
     end

--- a/test/requests/network/test_remove_subnets_from_virtual_network.rb
+++ b/test/requests/network/test_remove_subnets_from_virtual_network.rb
@@ -21,7 +21,7 @@ class TestRemoveSubnetsInVirtualNetwork < Minitest::Test
   def test_remove_subnets_in_virtual_network_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @virtual_networks.stub :get, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.remove_subnets_from_virtual_network('fog-test-rg', 'fog-test-virtual-network', ['mysubnet1'])
       end
     end

--- a/test/requests/network/test_reset_connection_shared_key.rb
+++ b/test/requests/network/test_reset_connection_shared_key.rb
@@ -17,7 +17,7 @@ class TestResetConnectionSharedKey < Minitest::Test
   def test_reset_connection_shared_key_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :reset_shared_key, response do
-      assert_raises(RuntimeError) { @service.reset_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection', '20') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.reset_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection', '20') }
     end
   end
 end

--- a/test/requests/network/test_set_connection_shared_key.rb
+++ b/test/requests/network/test_set_connection_shared_key.rb
@@ -17,7 +17,7 @@ class TestSetConnectionSharedKey < Minitest::Test
   def test_set_connection_shared_key_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @gateway_connections.stub :set_shared_key, response do
-      assert_raises(RuntimeError) { @service.set_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection', 'hello') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.set_connection_shared_key('fog-test-rg', 'fog-test-gateway-connection', 'hello') }
     end
   end
 end

--- a/test/requests/network/test_update_public_ip.rb
+++ b/test/requests/network/test_update_public_ip.rb
@@ -27,7 +27,7 @@ class TestUpdatePublicIp < Minitest::Test
   def test_update_public_ip_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @public_ips.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_public_ip('fog-test-rg', 'fog-test-public-ip', 'West US', 'Dynamic', '4', 'mylabel', @tags)
       end
     end

--- a/test/requests/resources/test_check_deployment_exists.rb
+++ b/test/requests/resources/test_check_deployment_exists.rb
@@ -23,7 +23,7 @@ class TestGetDeployment < Minitest::Test
   def test_check_deployment_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :check_existence, response do
-      assert_raises(RuntimeError) { @service.check_deployment_exists('fog-test-rg', 'fog-test-deployment') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_deployment_exists('fog-test-rg', 'fog-test-deployment') }
     end
   end
 end

--- a/test/requests/resources/test_check_resource_group_exists.rb
+++ b/test/requests/resources/test_check_resource_group_exists.rb
@@ -23,7 +23,7 @@ class TestGetResourceGroup < Minitest::Test
   def test_check_resource_group_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :check_existence, response do
-      assert_raises(RuntimeError) { @service.check_resource_group_exists('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_resource_group_exists('fog-test-rg') }
     end
   end
 end

--- a/test/requests/resources/test_create_deployment.rb
+++ b/test/requests/resources/test_create_deployment.rb
@@ -25,7 +25,7 @@ class TestCreateDeployment < Minitest::Test
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :validate, true do
       @deployments.stub :create_or_update, response do
-        assert_raises(RuntimeError) { @service.create_deployment(@resource_group, @deployment_name, @template_link, @parameters_link) }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.create_deployment(@resource_group, @deployment_name, @template_link, @parameters_link) }
       end
     end
   end

--- a/test/requests/resources/test_create_resource_group.rb
+++ b/test/requests/resources/test_create_resource_group.rb
@@ -19,7 +19,7 @@ class TestCreateResourceGroup < Minitest::Test
   def test_create_resource_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_resource_group('fog-test-rg', 'west us', @tags) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_resource_group('fog-test-rg', 'west us', @tags) }
     end
   end
 end

--- a/test/requests/resources/test_delete_deployment.rb
+++ b/test/requests/resources/test_delete_deployment.rb
@@ -19,7 +19,7 @@ class TestDeleteDeployment < Minitest::Test
   def test_list_deployment_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_deployment(@resource_group, @deployment_name) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_deployment(@resource_group, @deployment_name) }
     end
   end
 end

--- a/test/requests/resources/test_delete_resource_group.rb
+++ b/test/requests/resources/test_delete_resource_group.rb
@@ -18,7 +18,7 @@ class TestDeleteResourceGroup < Minitest::Test
   def test_delete_resource_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_resource_group('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_resource_group('fog-test-rg') }
     end
   end
 end

--- a/test/requests/resources/test_delete_resource_tag.rb
+++ b/test/requests/resources/test_delete_resource_tag.rb
@@ -23,7 +23,7 @@ class TestDeleteResourceTag < Minitest::Test
     @resources.stub :get, @resource_response do
       @resources.stub :create_or_update, response do
         resource_id = '/subscriptions/########-####-####-####-############/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.Network/{PROVIDER-NAME}/{RESOURCE-NAME}'
-        assert_raises(RuntimeError) { @service.delete_resource_tag(resource_id, 'tag_name', 'tag_value', 'api_version') }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.delete_resource_tag(resource_id, 'tag_name', 'tag_value', 'api_version') }
       end
     end
   end

--- a/test/requests/resources/test_get_deployment.rb
+++ b/test/requests/resources/test_get_deployment.rb
@@ -18,7 +18,7 @@ class TestGetDeployment < Minitest::Test
   def test_list_deployment_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_deployment('fog-test-rg', 'fog-test-deployment') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_deployment('fog-test-rg', 'fog-test-deployment') }
     end
   end
 end

--- a/test/requests/resources/test_get_resource_group.rb
+++ b/test/requests/resources/test_get_resource_group.rb
@@ -18,7 +18,7 @@ class TestGetResourceGroup < Minitest::Test
   def test_get_resource_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_resource_group('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_resource_group('fog-test-rg') }
     end
   end
 end

--- a/test/requests/resources/test_list_deployments.rb
+++ b/test/requests/resources/test_list_deployments.rb
@@ -19,7 +19,7 @@ class TestListDeployment < Minitest::Test
   def test_list_deployment_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @deployments.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_deployments(@resource_group) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_deployments(@resource_group) }
     end
   end
 end

--- a/test/requests/resources/test_list_resource_groups.rb
+++ b/test/requests/resources/test_list_resource_groups.rb
@@ -18,7 +18,7 @@ class TestListResourceGroups < Minitest::Test
   def test_list_resource_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resource_groups.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_resource_groups }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_resource_groups }
     end
   end
 end

--- a/test/requests/resources/test_list_tagged_resources.rb
+++ b/test/requests/resources/test_list_tagged_resources.rb
@@ -18,7 +18,7 @@ class TestListTags < Minitest::Test
   def test_list_tagged_resources_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @resources.stub :list_as_lazy, response do
-      assert_raises(RuntimeError) { @service.list_tagged_resources('test_key') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_tagged_resources('test_key') }
     end
   end
 end

--- a/test/requests/resources/test_tag_resource.rb
+++ b/test/requests/resources/test_tag_resource.rb
@@ -23,7 +23,7 @@ class TestTagResource < Minitest::Test
     @resources.stub :get, @resource_response do
       @resources.stub :create_or_update, response do
         resource_id = '/subscriptions/########-####-####-####-############/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.Network/{PROVIDER-NAME}/{RESOURCE-NAME}'
-        assert_raises(RuntimeError) { @service.tag_resource(resource_id, 'tag_name', 'tag_value', 'api_version') }
+        assert_raises(MsRestAzure::AzureOperationError) { @service.tag_resource(resource_id, 'tag_name', 'tag_value', 'api_version') }
       end
     end
   end

--- a/test/requests/sql/test_create_or_update_database.rb
+++ b/test/requests/sql/test_create_or_update_database.rb
@@ -19,7 +19,7 @@ class TestCreateOrUpdateDatabase < Minitest::Test
   def test_create_or_update_database_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @databases.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_or_update_database(@database_hash) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_database(@database_hash) }
     end
   end
 end

--- a/test/requests/sql/test_create_or_update_firewall_rule.rb
+++ b/test/requests/sql/test_create_or_update_firewall_rule.rb
@@ -19,7 +19,7 @@ class TestCreateOrUpdateFirewallRule < Minitest::Test
   def test_create_or_update_sql_server_firewall_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @firewall_rule.stub :create_or_update_firewall_rule, response do
-      assert_raises(RuntimeError) { @service.create_or_update_firewall_rule(@data_hash) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_firewall_rule(@data_hash) }
     end
   end
 end

--- a/test/requests/sql/test_create_or_update_sql_server.rb
+++ b/test/requests/sql/test_create_or_update_sql_server.rb
@@ -19,7 +19,7 @@ class TestCreateOrUpdateSqlServer < Minitest::Test
   def test_create_or_update_sql_server_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @server.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_or_update_sql_server(@data_hash) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_sql_server(@data_hash) }
     end
   end
 end

--- a/test/requests/sql/test_delete_database.rb
+++ b/test/requests/sql/test_delete_database.rb
@@ -17,7 +17,7 @@ class TestDeleteDatabase < Minitest::Test
   def test_delete_database_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @databases.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_database('fog-test-rg', 'fog-test-server-name', 'database-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_database('fog-test-rg', 'fog-test-server-name', 'database-name') }
     end
   end
 end

--- a/test/requests/sql/test_delete_firewall_rule.rb
+++ b/test/requests/sql/test_delete_firewall_rule.rb
@@ -17,7 +17,7 @@ class TestDeleteFirewallRule < Minitest::Test
   def test_delete_sql_server_firewall_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @firewall_rules.stub :delete_firewall_rule, response do
-      assert_raises(RuntimeError) { @service.delete_firewall_rule('fog-test-rg', 'fog-test-server-name', 'rule-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_firewall_rule('fog-test-rg', 'fog-test-server-name', 'rule-name') }
     end
   end
 end

--- a/test/requests/sql/test_delete_sql_server.rb
+++ b/test/requests/sql/test_delete_sql_server.rb
@@ -17,7 +17,7 @@ class TestDeleteSqlServer < Minitest::Test
   def test_delete_sql_server_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @servers.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_sql_server('fog-test-rg', 'fog-test-server-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_sql_server('fog-test-rg', 'fog-test-server-name') }
     end
   end
 end

--- a/test/requests/sql/test_get_database.rb
+++ b/test/requests/sql/test_get_database.rb
@@ -18,7 +18,7 @@ class TestGetDatabase < Minitest::Test
   def test_get_database_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @databases.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_database('fog-test-rg', 'fog-test-server-name', 'fog-test-database-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_database('fog-test-rg', 'fog-test-server-name', 'fog-test-database-name') }
     end
   end
 end

--- a/test/requests/sql/test_get_firewall_rule.rb
+++ b/test/requests/sql/test_get_firewall_rule.rb
@@ -18,7 +18,7 @@ class TestGetFirewallRule < Minitest::Test
   def test_get_sql_server_firewall_rule_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @servers.stub :get_firewall_rule, response do
-      assert_raises(RuntimeError) { @service.get_firewall_rule('fog-test-rg', 'fog-test-server-name', 'rule-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_firewall_rule('fog-test-rg', 'fog-test-server-name', 'rule-name') }
     end
   end
 end

--- a/test/requests/sql/test_get_sql_server.rb
+++ b/test/requests/sql/test_get_sql_server.rb
@@ -18,7 +18,7 @@ class TestGetSqlServer < Minitest::Test
   def test_get_sql_server_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @servers.stub :get_by_resource_group, response do
-      assert_raises(RuntimeError) { @service.get_sql_server('fog-test-rg', 'fog-test-server-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_sql_server('fog-test-rg', 'fog-test-server-name') }
     end
   end
 end

--- a/test/requests/sql/test_list_databases.rb
+++ b/test/requests/sql/test_list_databases.rb
@@ -18,7 +18,7 @@ class TestListDatabases < Minitest::Test
   def test_list_databases_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @database.stub :list_by_server, response do
-      assert_raises(RuntimeError) { @service.list_databases('fog-test-rg', 'fog-test-server-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_databases('fog-test-rg', 'fog-test-server-name') }
     end
   end
 end

--- a/test/requests/sql/test_list_firewall_rules.rb
+++ b/test/requests/sql/test_list_firewall_rules.rb
@@ -18,7 +18,7 @@ class TestListFirewallRules < Minitest::Test
   def test_list_sql_servers_firewall_rules_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @server.stub :list_firewall_rules, response do
-      assert_raises(RuntimeError) { @service.list_firewall_rules('fog-test-rg', 'server-name') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_firewall_rules('fog-test-rg', 'server-name') }
     end
   end
 end

--- a/test/requests/sql/test_list_sql_servers.rb
+++ b/test/requests/sql/test_list_sql_servers.rb
@@ -18,7 +18,7 @@ class TestListSqlServers < Minitest::Test
   def test_list_sql_servers_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @server.stub :list_by_resource_group, response do
-      assert_raises(RuntimeError) { @service.list_sql_servers('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_sql_servers('fog-test-rg') }
     end
   end
 end

--- a/test/requests/storage/test_acquire_blob_lease.rb
+++ b/test/requests/storage/test_acquire_blob_lease.rb
@@ -24,7 +24,7 @@ class TestAcquireBlobLease < Minitest::Test
   def test_acquire_blob_lease_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :acquire_blob_lease, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.acquire_blob_lease('test_container', 'test_blob')
       end
     end

--- a/test/requests/storage/test_acquire_container_lease.rb
+++ b/test/requests/storage/test_acquire_container_lease.rb
@@ -24,7 +24,7 @@ class TestAcquireContainerLease < Minitest::Test
   def test_acquire_container_lease_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :acquire_container_lease, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.acquire_container_lease('test_container')
       end
     end

--- a/test/requests/storage/test_check_storage_account_exists.rb
+++ b/test/requests/storage/test_check_storage_account_exists.rb
@@ -35,7 +35,7 @@ class TestCheckStorageAccountExists < Minitest::Test
   def test_check_storage_account_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @storage_accounts.stub :get_properties, response do
-      assert_raises(RuntimeError) { @service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_storage_account_exists('fog_test_rg', 'fogtestsasecond') }
     end
   end
 end

--- a/test/requests/storage/test_check_storage_account_name_availability.rb
+++ b/test/requests/storage/test_check_storage_account_name_availability.rb
@@ -29,7 +29,7 @@ class TestCheckStorageAccountNameAvailability < Minitest::Test
   def test_check_storage_account_name_availability_exception
     raise_exception = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception', 'code' => 'ResourceGroupNotFound' }) }
     @storage_accounts.stub :check_name_availability, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.check_storage_account_name_availability('teststorageaccount', 'Microsoft.Storage/storageAccounts') }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.check_storage_account_name_availability('teststorageaccount', 'Microsoft.Storage/storageAccounts') }
     end
   end
 end

--- a/test/requests/storage/test_commit_blob_blocks.rb
+++ b/test/requests/storage/test_commit_blob_blocks.rb
@@ -22,7 +22,7 @@ class TestCommitBlobBlocks < Minitest::Test
   def test_commit_blob_blocks_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :commit_blob_blocks, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.commit_blob_blocks('test_container', 'test_blob', [])
       end
     end

--- a/test/requests/storage/test_compare_container_blobs.rb
+++ b/test/requests/storage/test_compare_container_blobs.rb
@@ -24,7 +24,7 @@ class TestCompareContainerBlobs < Minitest::Test
   def test_compare_container_blobs_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @service.stub :get_identical_blobs_from_containers, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.compare_container_blobs('test_container1', 'test_container2')
       end
     end

--- a/test/requests/storage/test_copy_blob.rb
+++ b/test/requests/storage/test_copy_blob.rb
@@ -24,7 +24,7 @@ class TestCopyBlob < Minitest::Test
   def test_copy_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :copy_blob, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.copy_blob('destination_container', 'destination_blob', 'source_container', 'source_blob')
       end
     end

--- a/test/requests/storage/test_copy_blob_from_uri.rb
+++ b/test/requests/storage/test_copy_blob_from_uri.rb
@@ -24,7 +24,7 @@ class TestCopyBlobFromUri < Minitest::Test
   def test_copy_blob_from_uri_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :copy_blob_from_uri, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.copy_blob_from_uri('destination_container', 'destination_blob', 'source_uri')
       end
     end

--- a/test/requests/storage/test_create_block_blob.rb
+++ b/test/requests/storage/test_create_block_blob.rb
@@ -64,7 +64,7 @@ class TestCreateBlockBlob < Minitest::Test
   def test_create_block_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :create_block_blob, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.create_block_blob('test_container', 'test_blob', nil)
       end
     end

--- a/test/requests/storage/test_create_container.rb
+++ b/test/requests/storage/test_create_container.rb
@@ -24,7 +24,7 @@ class TestCreateContainer < Minitest::Test
   def test_create_container_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :create_container, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.create_container('test_container')
       end
     end

--- a/test/requests/storage/test_create_page_blob.rb
+++ b/test/requests/storage/test_create_page_blob.rb
@@ -22,7 +22,7 @@ class TestCreatePageBlob < Minitest::Test
   def test_create_page_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :create_page_blob, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.create_page_blob('test_container', 'test_blob', 1_024)
       end
     end

--- a/test/requests/storage/test_create_storage_account.rb
+++ b/test/requests/storage/test_create_storage_account.rb
@@ -28,7 +28,7 @@ class TestCreateStorageAccount < Minitest::Test
   def test_create_storage_account_exception
     raise_exception = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :create, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.create_storage_account(@storage_account_arguments) }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.create_storage_account(@storage_account_arguments) }
     end
   end
 end

--- a/test/requests/storage/test_delete_blob.rb
+++ b/test/requests/storage/test_delete_blob.rb
@@ -30,7 +30,7 @@ class TestDeleteBlob < Minitest::Test
   def test_delete_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :delete_blob, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.delete_blob('test_container', 'test_blob')
       end
     end

--- a/test/requests/storage/test_delete_container.rb
+++ b/test/requests/storage/test_delete_container.rb
@@ -30,7 +30,7 @@ class TestDeleteContainer < Minitest::Test
   def test_delete_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :delete_container, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.delete_container('test_container')
       end
     end

--- a/test/requests/storage/test_delete_storage_account.rb
+++ b/test/requests/storage/test_delete_storage_account.rb
@@ -22,7 +22,7 @@ class TestDeleteStorageAccount < Minitest::Test
   def test_delete_storage_account_exception
     raise_exception = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :delete, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.delete_storage_account('gateway-RG', 'fog_test_storage_account') }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.delete_storage_account('gateway-RG', 'fog_test_storage_account') }
     end
   end
 end

--- a/test/requests/storage/test_get_blob.rb
+++ b/test/requests/storage/test_get_blob.rb
@@ -38,7 +38,7 @@ class TestGetBlob < Minitest::Test
   def test_get_blob_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_blob, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.get_blob('test_container', 'test_blob')
       end
     end
@@ -112,7 +112,7 @@ class TestGetBlob < Minitest::Test
   def test_get_blob_with_block_given_not_exist
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_blob_properties, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.get_blob('test_container', 'test_blob') do |*chunk|
         end
       end
@@ -123,7 +123,7 @@ class TestGetBlob < Minitest::Test
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_blob_properties, @raw_cloud_blob do
       @blob_client.stub :get_blob, http_exception do
-        assert_raises(RuntimeError) do
+        assert_raises(Azure::Core::Http::HTTPError) do
           @service.get_blob('test_container', 'test_blob') do |*chunk|
           end
         end

--- a/test/requests/storage/test_get_blob_properties.rb
+++ b/test/requests/storage/test_get_blob_properties.rb
@@ -33,7 +33,7 @@ class TestGetBlobProperties < Minitest::Test
   def test_get_blob_properties_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_blob_properties, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.get_blob_properties('test_container', 'test_blob')
       end
     end

--- a/test/requests/storage/test_get_container_acl.rb
+++ b/test/requests/storage/test_get_container_acl.rb
@@ -25,7 +25,7 @@ class TestGetContainerAcl < Minitest::Test
   def test_get_container_acl_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_container_acl, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.get_container_acl('test_container')
       end
     end

--- a/test/requests/storage/test_get_container_properties.rb
+++ b/test/requests/storage/test_get_container_properties.rb
@@ -33,7 +33,7 @@ class TestGetContainerProperties < Minitest::Test
   def test_get_container_properties_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :get_container_properties, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.get_container_properties('test_container')
       end
     end

--- a/test/requests/storage/test_get_storage_access_keys.rb
+++ b/test/requests/storage/test_get_storage_access_keys.rb
@@ -18,7 +18,7 @@ class TestGetStorageAccessKeys < Minitest::Test
   def test_get_storage_access_keys_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :list_keys, response do
-      assert_raises(RuntimeError) { @service.get_storage_access_keys('fog-test-rg', 'fogstorageaccount') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_storage_access_keys('fog-test-rg', 'fogstorageaccount') }
     end
   end
 end

--- a/test/requests/storage/test_get_storage_account.rb
+++ b/test/requests/storage/test_get_storage_account.rb
@@ -19,7 +19,7 @@ class TestGetStorageAccount < Minitest::Test
   def test_list_storage_accounts_exeception
     raise_exception = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :get_properties, raise_exception do
-      assert_raises(RuntimeError) { @service.get_storage_account('fog_test_rg', 'fogtestsasecond') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_storage_account('fog_test_rg', 'fogtestsasecond') }
     end
   end
 end

--- a/test/requests/storage/test_list_blobs.rb
+++ b/test/requests/storage/test_list_blobs.rb
@@ -55,7 +55,7 @@ class TestListBlobs < Minitest::Test
   def test_list_blobs_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :list_blobs, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.list_blobs('test_container')
       end
     end

--- a/test/requests/storage/test_list_containers.rb
+++ b/test/requests/storage/test_list_containers.rb
@@ -34,7 +34,7 @@ class TestListContainers < Minitest::Test
   def test_list_containers_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :list_containers, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.list_containers
       end
     end

--- a/test/requests/storage/test_list_storage_accounts.rb
+++ b/test/requests/storage/test_list_storage_accounts.rb
@@ -31,7 +31,7 @@ class TestListStorageAccounts < Minitest::Test
   def test_list_storage_accounts_exeception
     raise_exception = -> { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :list, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.list_storage_accounts }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.list_storage_accounts }
     end
   end
 end

--- a/test/requests/storage/test_list_storage_accounts_for_rg.rb
+++ b/test/requests/storage/test_list_storage_accounts_for_rg.rb
@@ -31,7 +31,7 @@ class TestListStorageAccountsForRG < Minitest::Test
   def test_list_storage_accounts_for_rg_exception
     raise_exception = proc { fail MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :list_by_resource_group, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.list_storage_account_for_rg('gateway-RG') }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.list_storage_account_for_rg('gateway-RG') }
     end
   end
 end

--- a/test/requests/storage/test_put_blob_block.rb
+++ b/test/requests/storage/test_put_blob_block.rb
@@ -22,7 +22,7 @@ class TestPutBlobBlock < Minitest::Test
   def test_put_blob_block_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :put_blob_block, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_blob_block('test_container', 'test_blob', 'id', 'data')
       end
     end

--- a/test/requests/storage/test_put_blob_metadata.rb
+++ b/test/requests/storage/test_put_blob_metadata.rb
@@ -24,7 +24,7 @@ class TestPutBlobMetadata < Minitest::Test
   def test_put_blob_metadata_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :set_blob_metadata, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_blob_metadata('test_container', 'test_blob', @metadata)
       end
     end

--- a/test/requests/storage/test_put_blob_pages.rb
+++ b/test/requests/storage/test_put_blob_pages.rb
@@ -22,7 +22,7 @@ class TestPutBlobPages < Minitest::Test
   def test_put_blob_pages_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :put_blob_pages, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_blob_pages('test_container', 'test_blob', 0, 1024, 'data')
       end
     end

--- a/test/requests/storage/test_put_blob_properties.rb
+++ b/test/requests/storage/test_put_blob_properties.rb
@@ -27,7 +27,7 @@ class TestPutBlobProperties < Minitest::Test
   def test_put_blob_properties_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :set_blob_properties, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_blob_properties('test_container', 'test_blob', @properties)
       end
     end

--- a/test/requests/storage/test_put_container_acl.rb
+++ b/test/requests/storage/test_put_container_acl.rb
@@ -22,7 +22,7 @@ class TestPutContainerACL < Minitest::Test
   def test_put_container_acl_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :set_container_acl, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_container_acl('test_container', 'container')
       end
     end

--- a/test/requests/storage/test_put_container_metadata.rb
+++ b/test/requests/storage/test_put_container_metadata.rb
@@ -24,7 +24,7 @@ class TestPutContainerMetadata < Minitest::Test
   def test_put_container_metadata_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :set_container_metadata, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.put_container_metadata('test_container', @metadata)
       end
     end

--- a/test/requests/storage/test_release_blob_lease.rb
+++ b/test/requests/storage/test_release_blob_lease.rb
@@ -22,7 +22,7 @@ class TestReleaseBlobLease < Minitest::Test
   def test_release_blob_lease_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :release_blob_lease, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.release_blob_lease('test_container', 'test_blob', 'lease_id')
       end
     end

--- a/test/requests/storage/test_release_container_lease.rb
+++ b/test/requests/storage/test_release_container_lease.rb
@@ -22,7 +22,7 @@ class TestReleaseContainerLease < Minitest::Test
   def test_release_container_lease_http_exception
     http_exception = ->(*) { raise Azure::Core::Http::HTTPError.new(@mocked_response) }
     @blob_client.stub :release_container_lease, http_exception do
-      assert_raises(RuntimeError) do
+      assert_raises(Azure::Core::Http::HTTPError) do
         @service.release_container_lease('test_container', 'lease_id')
       end
     end

--- a/test/requests/storage/test_update_storage_account.rb
+++ b/test/requests/storage/test_update_storage_account.rb
@@ -28,7 +28,7 @@ class TestCreateStorageAccount < Minitest::Test
   def test_update_storage_account_exception
     raise_exception = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @storage_accounts.stub :update, raise_exception do
-      assert_raises(RuntimeError) { @azure_credentials.update_storage_account(@storage_account_arguments) }
+      assert_raises(MsRestAzure::AzureOperationError) { @azure_credentials.update_storage_account(@storage_account_arguments) }
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_endpoint_exists.rb
@@ -32,7 +32,7 @@ class TestCheckTrafficManagerEndpointExists < Minitest::Test
   def test_check_traffic_manager_endpoint_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @end_points.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_traffic_manager_endpoint_exists('fog-test-rg', 'fog-test-profile', 'fog-test-endpoint-name', 'fog-test-endpoint-type') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
+++ b/test/requests/traffic_manager/test_check_traffic_manager_profile_exists.rb
@@ -32,7 +32,7 @@ class TestCheckTrafficManagerProfileExists < Minitest::Test
   def test_check_traffic_manager_profile_exists_exception
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, create_mock_response, 'error' => { 'message' => 'mocked exception', 'code' => 'Exception' }) }
     @profiles.stub :get, response do
-      assert_raises(RuntimeError) { @service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.check_traffic_manager_profile_exists('fog-test-rg', 'fog-test-profile') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_create_traffic_manager_endpoint.rb
+++ b/test/requests/traffic_manager/test_create_traffic_manager_endpoint.rb
@@ -19,7 +19,7 @@ class TestCreateTrafficManagerEndPoint < Minitest::Test
   def test_create_traffic_manager_endpoint_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @end_points.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_or_update_traffic_manager_endpoint(@endpoint_hash) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_traffic_manager_endpoint(@endpoint_hash) }
     end
   end
 end

--- a/test/requests/traffic_manager/test_create_traffic_manager_profile.rb
+++ b/test/requests/traffic_manager/test_create_traffic_manager_profile.rb
@@ -19,7 +19,7 @@ class TestCreateTrafficManagerProfile < Minitest::Test
   def test_create_traffic_manager_profile_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @profiles.stub :create_or_update, response do
-      assert_raises(RuntimeError) { @service.create_or_update_traffic_manager_profile(@profile_hash) }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.create_or_update_traffic_manager_profile(@profile_hash) }
     end
   end
 end

--- a/test/requests/traffic_manager/test_delete_traffic_manager_endpoint.rb
+++ b/test/requests/traffic_manager/test_delete_traffic_manager_endpoint.rb
@@ -17,7 +17,7 @@ class TestDeleteTrafficManagerEndPoint < Minitest::Test
   def test_delete_traffic_manager_endpoint_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @end_points.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_traffic_manager_endpoint('fog-test-rg', 'fog-test-end-point', 'fog-test-profile', 'external') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_traffic_manager_endpoint('fog-test-rg', 'fog-test-end-point', 'fog-test-profile', 'external') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_delete_traffic_manager_profile.rb
+++ b/test/requests/traffic_manager/test_delete_traffic_manager_profile.rb
@@ -17,7 +17,7 @@ class TestDeleteTrafficManagerProfile < Minitest::Test
   def test_delete_traffic_manager_profile_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @profiles.stub :delete, response do
-      assert_raises(RuntimeError) { @service.delete_traffic_manager_profile('fog-test-rg', 'fog-test-profile') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.delete_traffic_manager_profile('fog-test-rg', 'fog-test-profile') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_get_traffic_manager_endpoint.rb
+++ b/test/requests/traffic_manager/test_get_traffic_manager_endpoint.rb
@@ -18,7 +18,7 @@ class TestGetTrafficManagerEndpoint < Minitest::Test
   def test_get_traffic_manager_endpoint_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @end_points.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_traffic_manager_end_point('fog-test-rg', 'fog-test-profile', 'wrong-param', 'wrong-param') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_traffic_manager_end_point('fog-test-rg', 'fog-test-profile', 'wrong-param', 'wrong-param') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_get_traffic_manager_profile.rb
+++ b/test/requests/traffic_manager/test_get_traffic_manager_profile.rb
@@ -18,7 +18,7 @@ class TestGetTrafficManagerProfile < Minitest::Test
   def test_get_traffic_manager_profile_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @profiles.stub :get, response do
-      assert_raises(RuntimeError) { @service.get_traffic_manager_profile('fog-test-rg', 'fog-test-profile') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.get_traffic_manager_profile('fog-test-rg', 'fog-test-profile') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_list_traffic_manager_profiles.rb
+++ b/test/requests/traffic_manager/test_list_traffic_manager_profiles.rb
@@ -18,7 +18,7 @@ class TestListTrafficManagerProfiles < Minitest::Test
   def test_list_traffic_manager_profiles_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @profiles.stub :list_all_in_resource_group, response do
-      assert_raises(RuntimeError) { @service.list_traffic_manager_profiles('fog-test-rg') }
+      assert_raises(MsRestAzure::AzureOperationError) { @service.list_traffic_manager_profiles('fog-test-rg') }
     end
   end
 end

--- a/test/requests/traffic_manager/test_update_traffic_manager_endpoint.rb
+++ b/test/requests/traffic_manager/test_update_traffic_manager_endpoint.rb
@@ -19,7 +19,7 @@ class TestUpdateTrafficManagerEndPoint < Minitest::Test
   def test_update_traffic_manager_profile_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @end_points.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_traffic_manager_endpoint(resource_group: 'resource-group', name: 'name', traffic_manager_profile_name: 'traffic_manager_profile_name', type: 'type')
       end
     end

--- a/test/requests/traffic_manager/test_update_traffic_manager_profile.rb
+++ b/test/requests/traffic_manager/test_update_traffic_manager_profile.rb
@@ -19,7 +19,7 @@ class TestUpdateTrafficManagerProfile < Minitest::Test
   def test_update_traffic_manager_profile_exception_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
     @profiles.stub :create_or_update, response do
-      assert_raises RuntimeError do
+      assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_traffic_manager_profile(resource_group: 'fog-test-rg')
       end
     end


### PR DESCRIPTION
`fog-azure-rm`'s `raise_azure_exception` method was taking in `MsRestAzure::AzureOperationError` and `Azure::Core::Http::HTTPError` errors and raising them as `runtime` errors. What has been done is that new custom error classes for `fog-azure-rm` have been created that inherit from the same above mentioned classes and now instead of `runtime` errors, we raise our custom errors