### PR TITLE
Use Autoload

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 ## Usage
 
 You can use this gem against the Microsoft Azure Resource Manager Services in the cloud. Of course, to use the Microsoft Azure Resource Manager Services in the cloud, you need to first [create a Microsoft Azure account](http://www.azure.com/en-us/pricing/free-trial/).
-* Set 'LOCATION' constant based on the Azure cloud you are using in [config.rb] (https://github.com/fog/fog-azure-rm/blob/master/lib/fog/azurerm/config.rb) file. By default it will be 'eastus'.
+* Set 'AzureRm::Config.location' based on the Azure cloud you are using in an initializer. By default it will be 'eastus'.
 
 ### Authentication
 

--- a/lib/fog/azurerm.rb
+++ b/lib/fog/azurerm.rb
@@ -1,21 +1,11 @@
 require 'ms_rest_azure'
 require 'azure/core/http/http_error'
 require 'erb'
-require 'fog/azurerm/config'
 require 'fog/azurerm/constants'
 require 'fog/azurerm/utilities/general'
 require 'fog/azurerm/version'
 require 'fog/core'
 require 'fog/json'
-require 'fog/azurerm/models/compute/caching_types'
-require 'fog/azurerm/models/compute/disk_create_option_types'
-require 'fog/azurerm/models/network/ipallocation_method'
-require 'fog/azurerm/models/network/security_rule_access'
-require 'fog/azurerm/models/network/security_rule_direction'
-require 'fog/azurerm/models/network/security_rule_protocol'
-require 'fog/azurerm/models/storage/sku_name'
-require 'fog/azurerm/models/storage/sku_tier'
-require 'fog/azurerm/models/storage/kind'
 
 module Fog
   # Autoload Module for Credentials
@@ -71,6 +61,7 @@ module Fog
   # Autoload Module for Response::Asynchronous
   module AzureRM
     autoload :AsyncResponse, File.expand_path('azurerm/async_response', __dir__)
+    autoload :Config, File.expand_path('azurerm/config', __dir__)
   end
 
   # Main AzureRM fog Provider Module

--- a/lib/fog/azurerm/config.rb
+++ b/lib/fog/azurerm/config.rb
@@ -1,1 +1,11 @@
-LOCATION = 'eastus'.freeze
+module AzureRM
+  class Config
+    def self.location
+      @location || 'eastus'.freeze
+    end
+
+    def self.location=(location)
+      @location = location
+    end
+  end
+end

--- a/test/integration/application_gateway.rb
+++ b/test/integration/application_gateway.rb
@@ -47,12 +47,12 @@ app_gateway_name = "AG#{time}"
 begin
   resource_group = resource.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: virtual_network_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     dns_servers: %w(10.1.0.0 10.2.0.0),
     address_prefixes: %w(10.1.0.0/16 10.2.0.0/16)
@@ -68,7 +68,7 @@ begin
   network.public_ips.create(
     name: public_ip_name,
     resource_group: resource_group_name,
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
@@ -87,7 +87,7 @@ begin
 
   app_gateway = application_gateway.gateways.create(
     name: app_gateway_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags,
     sku_name: 'Standard_Medium',

--- a/test/integration/availability_set.rb
+++ b/test/integration/availability_set.rb
@@ -45,7 +45,7 @@ begin
   puts "Create resource group (#{resource_group_name}):"
   resource_group = rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
   puts "Created resource group! [#{resource_group.name}]"
 
@@ -76,7 +76,7 @@ begin
   puts "Create unmanaged default availability set (#{unmanaged_as_name_default}):"
   avail_set = compute.availability_sets.create(
     name: unmanaged_as_name_default,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags
   )
@@ -92,7 +92,7 @@ begin
   puts "Create unmanaged custom availability set (#{unmanaged_as_name_custom}):"
   avail_set = compute.availability_sets.create(
     name: unmanaged_as_name_custom,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags,
     platform_fault_domain_count: 3,
@@ -110,7 +110,7 @@ begin
   puts "Create managed default availability set (#{managed_as_name_default}):"
   avail_set = compute.availability_sets.create(
     name: managed_as_name_default,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags,
     use_managed_disk: true
@@ -127,7 +127,7 @@ begin
   puts "Create managed custom availability set (#{managed_as_name_custom}):"
   avail_set = compute.availability_sets.create(
     name: managed_as_name_custom,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags,
     platform_fault_domain_count: 2,

--- a/test/integration/blob.rb
+++ b/test/integration/blob.rb
@@ -40,12 +40,12 @@ test_container_name = "tcon#{time}"
 begin
   resource_group = rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account = storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name
   )
 

--- a/test/integration/container.rb
+++ b/test/integration/container.rb
@@ -40,14 +40,14 @@ test_container_name = "tcon#{time}"
 begin
   resource_group = rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account_name = "sa#{current_time}"
 
   storage_account = storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name
   )
 

--- a/test/integration/data_disk.rb
+++ b/test/integration/data_disk.rb
@@ -40,12 +40,12 @@ test_container_name = 'disks'
 begin
   resource_group = rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account = storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name
   )
 

--- a/test/integration/deployment.rb
+++ b/test/integration/deployment.rb
@@ -22,7 +22,7 @@ resources = Fog::Resources::AzureRM.new(
 begin
   resource_group = resources.resource_groups.create(
     name: 'TestRG-ZN',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################

--- a/test/integration/express_route_circuit.rb
+++ b/test/integration/express_route_circuit.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resources.resource_groups.create(
     name: 'TestRG-ER',
-    location: LOCATION
+    location: Config.location
   )
   Fog::Logger.debug 'Resource Group created!'
 
@@ -46,7 +46,7 @@ begin
 
   express_route_circuit = network.express_route_circuits.create(
     name: 'testERCircuit',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'

--- a/test/integration/external_load_balancer.rb
+++ b/test/integration/external_load_balancer.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-LB',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-LB',
     dns_servers: %w(10.1.0.0 10.2.0.0),
     address_prefixes: %w(10.1.0.0/16 10.2.0.0/16)
@@ -50,7 +50,7 @@ begin
   pip = network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-LB',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
@@ -68,7 +68,7 @@ begin
   load_balancer = network.load_balancers.create(
     name: 'lb',
     resource_group: 'TestRG-LB',
-    location: LOCATION,
+    location: Config.location,
     frontend_ip_configurations:
     [
       {

--- a/test/integration/internal_load_balancer.rb
+++ b/test/integration/internal_load_balancer.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'NRP-RG-Fog',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: 'NRPVNet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'NRP-RG-Fog',
     dns_servers: %w(10.1.0.0 10.2.0.0),
     address_prefixes: %w(10.1.0.0/16 10.2.0.0/16)
@@ -54,7 +54,7 @@ begin
   load_balancer = network.load_balancers.create(
     name: 'lb',
     resource_group: 'NRP-RG-Fog',
-    location: LOCATION,
+    location: Config.location,
     frontend_ip_configurations:
       [
         {

--- a/test/integration/local_network_gateway.rb
+++ b/test/integration/local_network_gateway.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resource.resource_groups.create(
     name: 'TestRG-LNG',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -45,7 +45,7 @@ begin
 
   local_network_gateway = network.local_network_gateways.create(
     name: 'testlocalnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'

--- a/test/integration/managed_disk.rb
+++ b/test/integration/managed_disk.rb
@@ -39,7 +39,7 @@ disk_name           = "MD#{time}"
 begin
   rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -57,7 +57,7 @@ begin
 
   disk = compute.managed_disks.create(
     name: disk_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group_name: resource_group_name,
     tags: tags,
     account_type: 'Premium_LRS',

--- a/test/integration/network_interface.rb
+++ b/test/integration/network_interface.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-NI',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-NI',
     network_address_list: '10.1.0.0/16,10.2.0.0/16'
   )
@@ -56,21 +56,21 @@ begin
   network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-NI',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: 'Dynamic'
   )
 
   network.public_ips.create(
     name: 'mypubip1',
     resource_group: 'TestRG-NI',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: 'Dynamic'
   )
 
   nsg = network.network_security_groups.create(
     name: 'test_nsg',
     resource_group: 'TestRG-NI',
-    location: LOCATION,
+    location: Config.location,
     security_rules:
       [
         {
@@ -101,7 +101,7 @@ begin
   network_interface = network.network_interfaces.create(
     name: 'NetInt',
     resource_group: 'TestRG-NI',
-    location: LOCATION,
+    location: Config.location,
     network_security_group_id: nsg.id,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/TestRG-NI/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     public_ip_address_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/TestRG-NI/providers/Microsoft.Network/publicIPAddresses/mypubip",

--- a/test/integration/network_security_group.rb
+++ b/test/integration/network_security_group.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-NSG',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -46,7 +46,7 @@ begin
   network_security_group = network.network_security_groups.create(
     name: 'testGroup',
     resource_group: 'TestRG-NSG',
-    location: LOCATION,
+    location: Config.location,
     security_rules: [{
       name: 'testRule',
       protocol: Fog::ARM::Network::Models::SecurityRuleProtocol::Tcp,

--- a/test/integration/network_security_rule.rb
+++ b/test/integration/network_security_rule.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-NSR',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -39,7 +39,7 @@ begin
   network.network_security_groups.create(
     name: 'testGroup',
     resource_group: 'TestRG-NSR',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################

--- a/test/integration/public_ip.rb
+++ b/test/integration/public_ip.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-PB',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -46,7 +46,7 @@ begin
   public_ip = network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-PB',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic,
     tags: { key: 'value' }
   )

--- a/test/integration/record_set.rb
+++ b/test/integration/record_set.rb
@@ -29,7 +29,7 @@ dns = Fog::DNS::AzureRM.new(
 begin
   resource_group = resource.resource_groups.create(
     name: 'TestRG-RS',
-    location: LOCATION
+    location: Config.location
   )
 
   dns.zones.create(

--- a/test/integration/resource_tag.rb
+++ b/test/integration/resource_tag.rb
@@ -29,13 +29,13 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resources.resource_groups.create(
     name: 'TestRG-RT',
-    location: LOCATION
+    location: Config.location
   )
 
   resource_id = network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-RT',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Static
   ).id
 

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -43,14 +43,14 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-VM',
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account_name = "sa#{current_time}"
 
   storage_account = storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VM',
     account_type: 'Standard',
     replication: 'LRS'
@@ -58,7 +58,7 @@ begin
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VM',
     network_address_list: '10.1.0.0/16,10.2.0.0/16'
   )
@@ -73,7 +73,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt',
     resource_group: 'TestRG-VM',
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/TestRG-VM/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -82,7 +82,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt2',
     resource_group: 'TestRG-VM',
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/TestRG-VM/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -105,7 +105,7 @@ begin
 
   virtual_machine = compute.servers.create(
     name: 'TestVM',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VM',
     tags: tags,
     vm_size: 'Basic_A0',
@@ -132,7 +132,7 @@ begin
 
   managed_vm = compute.servers.create(
     name: 'TestVM-Managed',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VM',
     vm_size: 'Basic_A0',
     storage_account_name: nil,
@@ -159,7 +159,7 @@ begin
 
   async_response = compute.servers.create_async(
     name: 'TestVM',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VM',
     tags: tags,
     vm_size: 'Basic_A0',
@@ -228,7 +228,7 @@ begin
 
   managed_disk = compute.managed_disks.create(
     name: 'ManagedDataDisk',
-    location: LOCATION,
+    location: Config.location,
     resource_group_name: 'TestRG-VM',
     account_type: 'Standard_LRS',
     disk_size_gb: 100,

--- a/test/integration/server_custom_image.rb
+++ b/test/integration/server_custom_image.rb
@@ -45,14 +45,14 @@ RG_NAME = 'TestRG-CustomVM'.freeze
 begin
   resource_group = rs.resource_groups.create(
     name: RG_NAME,
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account_name = "sa#{current_time}"
 
   storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: RG_NAME,
     account_type: 'Standard',
     replication: 'LRS'
@@ -60,7 +60,7 @@ begin
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: RG_NAME,
     network_address_list: '10.1.0.0/16,10.2.0.0/16'
   )
@@ -75,7 +75,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt',
     resource_group: RG_NAME,
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/#{RG_NAME}/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -84,7 +84,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt2',
     resource_group: RG_NAME,
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/#{RG_NAME}/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -93,7 +93,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt3',
     resource_group: RG_NAME,
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/#{RG_NAME}/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -107,7 +107,7 @@ begin
 
   custom_image_virtual_machine = compute.servers.create(
     name: 'TestVM',
-    location: LOCATION,
+    location: Config.location,
     resource_group: RG_NAME,
     storage_account_name: storage_account_name,
     vm_size: 'Basic_A0',
@@ -127,7 +127,7 @@ begin
 
   custom_image_virtual_machine_managed = compute.servers.create(
     name: 'TestVM-Managed',
-    location: LOCATION,
+    location: Config.location,
     resource_group: RG_NAME,
     storage_account_name: storage_account_name,
     vm_size: 'Basic_A0',
@@ -150,7 +150,7 @@ begin
 
   async_response = compute.servers.create_async(
     name: 'TestVM-ManagedAsync',
-    location: LOCATION,
+    location: Config.location,
     resource_group: RG_NAME,
     storage_account_name: storage_account_name,
     vm_size: 'Basic_A0',

--- a/test/integration/sql_server.rb
+++ b/test/integration/sql_server.rb
@@ -29,7 +29,7 @@ azure_sql_service = Fog::Sql::AzureRM.new(
 begin
   resource_group = resources.resource_groups.create(
     name: 'TestRG-SQL',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -49,7 +49,7 @@ begin
   sql_server = azure_sql_service.sql_servers.create(
     name: server_name,
     resource_group: 'TestRG-SQL',
-    location: LOCATION,
+    location: Config.location,
     tags: tags,
     version: '2.0',
     administrator_login: 'testserveradmin',
@@ -72,7 +72,7 @@ begin
   sql_database = azure_sql_service.sql_databases.create(
     name: database_name,
     resource_group: 'TestRG-SQL',
-    location: LOCATION,
+    location: Config.location,
     tags: tags,
     server_name: server_name
   )

--- a/test/integration/storage_account.rb
+++ b/test/integration/storage_account.rb
@@ -41,7 +41,7 @@ premium_storage_acc = "premsa#{time}"
 begin
   resource_group = rs.resource_groups.create(
     name: resource_group_name,
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -66,7 +66,7 @@ begin
 
   storage_account = storage.storage_accounts.create(
     name: lrs_storage_account,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     tags: tags
   )
@@ -78,7 +78,7 @@ begin
 
   storage_account = storage.storage_accounts.create(
     name: grs_storage_account,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     sku_name: Fog::ARM::Storage::Models::SkuTier::Standard,
     replication: 'GRS',
@@ -93,7 +93,7 @@ begin
 
   storage_account = storage.storage_accounts.create(
     name: premium_storage_acc,
-    location: LOCATION,
+    location: Config.location,
     resource_group: resource_group_name,
     sku_name: Fog::ARM::Storage::Models::SkuTier::Premium,
     replication: 'LRS',

--- a/test/integration/subnet.rb
+++ b/test/integration/subnet.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-SN',
-    location: LOCATION
+    location: Config.location
   )
 
   virtual_network = network.virtual_networks.create(
     name:             'testVnet',
-    location:         LOCATION,
+    location:         Config.location,
     resource_group:   'TestRG-SN',
     dns_servers:       %w(10.1.0.0 10.2.0.0),
     address_prefixes:  %w(10.1.0.0/16 10.2.0.0/16)
@@ -43,7 +43,7 @@ begin
   network_security_group = network.network_security_groups.create(
     name: 'testGroup',
     resource_group: resource_group.name,
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################

--- a/test/integration/traffic_manager.rb
+++ b/test/integration/traffic_manager.rb
@@ -29,7 +29,7 @@ traffic_manager = Fog::TrafficManager::AzureRM.new(
 begin
   resource_group = resources.resource_groups.create(
     name: 'TestRG-TM',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################

--- a/test/integration/virtual_machine_extension.rb
+++ b/test/integration/virtual_machine_extension.rb
@@ -43,13 +43,13 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-VME',
-    location: LOCATION
+    location: Config.location
   )
 
   storage_account_name = "sa#{current_time}"
   storage.storage_accounts.create(
     name: storage_account_name,
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VME',
     account_type: 'Standard',
     replication: 'LRS'
@@ -57,7 +57,7 @@ begin
 
   network.virtual_networks.create(
     name:             'testVnet',
-    location:         LOCATION,
+    location:         Config.location,
     resource_group:   'TestRG-VME',
     network_address_list:  '10.1.0.0/16,10.2.0.0/16'
   )
@@ -72,7 +72,7 @@ begin
   network.network_interfaces.create(
     name: 'NetInt',
     resource_group: 'TestRG-VME',
-    location: LOCATION,
+    location: Config.location,
     subnet_id: "/subscriptions/#{azure_credentials['subscription_id']}/resourceGroups/TestRG-VME/providers/Microsoft.Network/virtualNetworks/testVnet/subnets/mysubnet",
     ip_configuration_name: 'testIpConfiguration',
     private_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
@@ -80,7 +80,7 @@ begin
 
   compute.servers.create(
     name: 'TestVM',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VME',
     vm_size: 'Basic_A0',
     storage_account_name: storage_account_name,
@@ -108,7 +108,7 @@ begin
 
   vm_extension = compute.virtual_machine_extensions.create(
     resource_group: 'TestRG-VME',
-    location: LOCATION,
+    location: Config.location,
     vm_name: 'TestVM',
     name: 'IaaSAntimalware',
     publisher: 'Microsoft.Azure.Security',

--- a/test/integration/virtual_network.rb
+++ b/test/integration/virtual_network.rb
@@ -29,7 +29,7 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-VN',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################
@@ -45,7 +45,7 @@ begin
 
   virtual_network = network.virtual_networks.create(
     name:             'testVnet',
-    location:         LOCATION,
+    location:         Config.location,
     resource_group:   resource_group.name,
     subnets:          [{
       name: 'mysubnet',

--- a/test/integration/virtual_network_gateway.rb
+++ b/test/integration/virtual_network_gateway.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resource.resource_groups.create(
     name: 'TestRG-VNG',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-VNG',
     network_address_list: '10.1.0.0/16,10.2.0.0/16'
   )
@@ -49,7 +49,7 @@ begin
   network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-VNG',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
@@ -66,7 +66,7 @@ begin
 
   virtual_network_gateway = network.virtual_network_gateways.create(
     name: 'testnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'

--- a/test/integration/virtual_network_gateway_connection.rb
+++ b/test/integration/virtual_network_gateway_connection.rb
@@ -29,19 +29,19 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resource.resource_groups.create(
     name: 'TestRG-GC',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name:             'testVnet',
-    location:         LOCATION,
+    location:         Config.location,
     resource_group:   'TestRG-GC',
     address_prefixes:  %w(10.1.0.0/16 10.2.0.0/16)
   )
 
   network.virtual_networks.create(
     name:             'testVnet2',
-    location:         LOCATION,
+    location:         Config.location,
     resource_group:   'TestRG-GC',
     address_prefixes:  %w(10.3.0.0/16 10.4.0.0/16)
   )
@@ -63,20 +63,20 @@ begin
   network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-GC',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
   network.public_ips.create(
     name: 'mypubip2',
     resource_group: 'TestRG-GC',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
   network.local_network_gateways.create(
     name: 'testlocalnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'
@@ -91,7 +91,7 @@ begin
 
   network.virtual_network_gateways.create(
     name: 'testnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'
@@ -122,7 +122,7 @@ begin
 
   network.virtual_network_gateways.create(
     name: 'testnetworkgateway2',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'
@@ -164,7 +164,7 @@ begin
 
   virtual_network_gateway_connection = network.virtual_network_gateway_connections.create(
     name: 'testnetworkgateway2-to-testnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-GC',
     virtual_network_gateway1: {
       name: 'testnetworkgateway2',

--- a/test/integration/virtual_network_gateway_connection_to_express_route.rb
+++ b/test/integration/virtual_network_gateway_connection_to_express_route.rb
@@ -29,12 +29,12 @@ network = Fog::Network::AzureRM.new(
 begin
   resource_group = resource.resource_groups.create(
     name: 'TestRG-GCE',
-    location: LOCATION
+    location: Config.location
   )
 
   network.virtual_networks.create(
     name: 'testVnet',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-GCE',
     network_address_list: '10.1.0.0/16,10.2.0.0/16'
   )
@@ -49,13 +49,13 @@ begin
   network.public_ips.create(
     name: 'mypubip',
     resource_group: 'TestRG-GCE',
-    location: LOCATION,
+    location: Config.location,
     public_ip_allocation_method: Fog::ARM::Network::Models::IPAllocationMethod::Dynamic
   )
 
   network.virtual_network_gateways.create(
     name: 'testnetworkgateway',
-    location: LOCATION,
+    location: Config.location,
     tags: {
       key1: 'value1',
       key2: 'value2'
@@ -86,7 +86,7 @@ begin
 
   connection = network.virtual_network_gateway_connections.create(
     name: 'testnetworkgateway-to-expressroute',
-    location: LOCATION,
+    location: Config.location,
     resource_group: 'TestRG-GCE',
     virtual_network_gateway1: {
       name: 'testnetworkgateway',

--- a/test/integration/zone.rb
+++ b/test/integration/zone.rb
@@ -30,7 +30,7 @@ dns = Fog::DNS.new(
 begin
   resource_group = rs.resource_groups.create(
     name: 'TestRG-ZN',
-    location: LOCATION
+    location: Config.location
   )
 
   ########################################################################################################################


### PR DESCRIPTION
I've started this to change usage of `require` to `autoload` but i did find some stuff that worried me so i've also fixed the `LOCATION` Constant.
I would like to ask you guys why are you using plain constants and methods out of the `Fog::AzureRM` namespace?
This would give clashing issues to the end user if he defines methods or Constants with the same names. We need to move everything to the `Fog::AzureRm` namespace.
Since there is a ton of changes, i will send the rest in another PR once this one gets merged.