### PR TITLE
OS Disk Id Attribute Added to Compute

### DIFF
--- a/lib/fog/azurerm/models/compute/server.rb
+++ b/lib/fog/azurerm/models/compute/server.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :vm_size
         attribute :storage_account_name
         attribute :os_disk_name
+        attribute :os_disk_id
         attribute :os_disk_vhd_uri
         attribute :os_disk_caching
         attribute :publisher
@@ -46,6 +47,10 @@ module Fog
           hash['vm_size'] = vm.hardware_profile.vm_size unless vm.hardware_profile.vm_size.nil?
           unless vm.storage_profile.nil?
             hash['os_disk_name'] = vm.storage_profile.os_disk.name
+
+            subscription_id = get_subscription_id(vm.id)
+            hash['os_disk_id'] = "/subscriptions/#{subscription_id}/resourceGroups/#{hash['resource_group']}/providers/Microsoft.Compute/disks/#{hash['os_disk_name']}"
+
             hash['os_disk_size'] = vm.storage_profile.os_disk.disk_size_gb
             if vm.storage_profile.os_disk.vhd.nil?
               hash['managed_disk_storage_type'] = vm.storage_profile.os_disk.managed_disk.storage_account_type

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -177,3 +177,7 @@ end
 def get_image_name(id)
   id.split('/').last
 end
+
+def get_subscription_id(id)
+  id.split('/')[2]
+end

--- a/test/api_stub/models/compute/server.rb
+++ b/test/api_stub/models/compute/server.rb
@@ -21,6 +21,7 @@ module ApiStub
                 },
                 'osDisk' => {
                   'name' => 'fog-test-server_os_disk',
+                  'id' => '/subscriptions/########-####-####-####-############/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/fog-test-server_os_disk',
                   'vhd' => {
                     'uri' => 'http://storageAccount.blob.core.windows.net/vhds/fog-test-server_os_disk.vhd'
                   }

--- a/test/api_stub/requests/compute/virtual_machine.rb
+++ b/test/api_stub/requests/compute/virtual_machine.rb
@@ -243,6 +243,7 @@ module ApiStub
                 },
                 "osDisk": {
                   "name":"myosdisk1",
+                  "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                   "vhd": {
                     "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                   },
@@ -320,6 +321,7 @@ module ApiStub
                 },
                 "osDisk": {
                   "name":"myosdisk1",
+                  "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                   "vhd": {
                     "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                   },
@@ -397,6 +399,7 @@ module ApiStub
                 },
                 "osDisk": {
                   "name":"myosdisk1",
+                  "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                   "vhd": {
                     "uri":"https://custimagestorage.blob.core.windows.net/customimage/trusty-server-cloudimg-amd64-disk1.vhd"
                   },
@@ -474,6 +477,7 @@ module ApiStub
                 },
                 "osDisk": {
                   "name":"myosdisk1",
+                  "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                   "vhd": {
                     "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                   },
@@ -546,6 +550,7 @@ module ApiStub
                     'osDisk' =>
                       {
                         'name' => 'myosdisk1',
+                        'id' => '/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1',
                         'vhd' =>
                           {
                             'uri' => 'http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd'
@@ -651,6 +656,7 @@ module ApiStub
                     },
                     "osDisk": {
                       "name":"myosdisk1",
+                      "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                       "vhd": {
                         "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                       },
@@ -809,6 +815,7 @@ module ApiStub
                     },
                     "osDisk": {
                       "name":"myosdisk1",
+                      "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                       "vhd": {
                         "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                       },
@@ -896,6 +903,7 @@ module ApiStub
                     },
                     "osDisk": {
                       "name":"myosdisk1",
+                      "id":"/subscriptions/{subscription-id}/resourceGroups/fog-test-rg/providers/Microsoft.Compute/disks/myosdisk1",
                       "vhd": {
                         "uri":"http://mystorage1.blob.core.windows.net/vhds/myosdisk1.vhd"
                       },

--- a/test/models/compute/test_server.rb
+++ b/test/models/compute/test_server.rb
@@ -38,6 +38,7 @@ class TestServer < Minitest::Test
       :vm_size,
       :storage_account_name,
       :os_disk_name,
+      :os_disk_id,
       :os_disk_vhd_uri,
       :os_disk_caching,
       :publisher,


### PR DESCRIPTION
`os_disk_id` attribute has been added to the Fog::AzureRM's model of `Compute`. Unit tests and integration tests have been run accordingly.