### PR TITLE
Release 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.7
+
+**Added:**
+- Support added to list resources in a resource group
+- Added OS disk id attribute to the 'Compute' model 
+
 ## 0.4.6
 
 **Added:**

--- a/lib/fog/azurerm/version.rb
+++ b/lib/fog/azurerm/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AzureRM
-    VERSION = '0.4.6'.freeze
+    VERSION = '0.4.7'.freeze
   end
 end


### PR DESCRIPTION
New `fog-azure-rm` gem version `0.4.7`

**Changes Made**
- Support added to list resources in a resource group
- Added OS disk id attribute to the 'Compute' model 
 