### PR TITLE
Correct get blob properties mock, fixes #387.

### DIFF
--- a/lib/fog/azurerm/requests/storage/get_blob_properties.rb
+++ b/lib/fog/azurerm/requests/storage/get_blob_properties.rb
@@ -20,8 +20,6 @@ module Fog
 
       # This class provides the mock implementation for unit tests.
       class Mock
-        require 'azure/storage'
-
         def get_blob_properties(*)
           blob = Azure::Storage::Blob::Blob.new
           blob.name = 'test_blob'

--- a/lib/fog/azurerm/requests/storage/get_blob_properties.rb
+++ b/lib/fog/azurerm/requests/storage/get_blob_properties.rb
@@ -20,11 +20,13 @@ module Fog
 
       # This class provides the mock implementation for unit tests.
       class Mock
+        require 'azure/storage'
+
         def get_blob_properties(*)
-          {
-            'name' => 'test_blob',
-            'metadata' => {},
-            'properties' => {
+          blob = Azure::Storage::Blob::Blob.new
+          blob.name = 'test_blob'
+          blob.metadata = {}
+          blob.properties = {
               'last_modified' => 'Mon, 04 Jul 2016 09:30:31 GMT',
               'etag' => '0x8D3A3EDD7C2B777',
               'lease_status' => 'unlocked',
@@ -47,7 +49,7 @@ module Fog
               'copy_status_description' => nil,
               'accept_ranges' => 0
             }
-          }
+          blob
         end
       end
     end

--- a/lib/fog/azurerm/requests/storage/get_blob_properties.rb
+++ b/lib/fog/azurerm/requests/storage/get_blob_properties.rb
@@ -25,27 +25,27 @@ module Fog
           blob.name = 'test_blob'
           blob.metadata = {}
           blob.properties = {
-              'last_modified' => 'Mon, 04 Jul 2016 09:30:31 GMT',
-              'etag' => '0x8D3A3EDD7C2B777',
-              'lease_status' => 'unlocked',
-              'lease_state' => 'available',
-              'lease_duration' => nil,
-              'content_length' => 4_194_304,
-              'content_type' => 'application/octet-stream',
-              'content_encoding' => nil,
-              'content_language' => nil,
-              'content_disposition' => nil,
-              'content_md5' => 'tXAohIyxuu/t94Lp/ujeRw==',
-              'cache_control' => nil,
-              'sequence_number' => 0,
-              'blob_type' => 'PageBlob',
-              'copy_id' => '095adc3b-e277-4c3d-97e0-0abca881f60c',
-              'copy_status' => 'success',
-              'copy_source' => 'https://testaccount.blob.core.windows.net/testblob/4m?snapshot=2016-02-04T08%3A35%3A50.3157696Z',
-              'copy_progress' => '4194304/4194304',
-              'copy_completion_time' => 'Thu, 04 Feb 2016 08:35:52 GMT',
-              'copy_status_description' => nil,
-              'accept_ranges' => 0
+              last_modified: 'Mon, 04 Jul 2016 09:30:31 GMT',
+              etag: '0x8D3A3EDD7C2B777',
+              lease_status: 'unlocked',
+              lease_state: 'available',
+              lease_duration: nil,
+              content_length: 4_194_304,
+              content_type: 'application/octet-stream',
+              content_encoding: nil,
+              content_language: nil,
+              content_disposition: nil,
+              content_md5: 'tXAohIyxuu/t94Lp/ujeRw==',
+              cache_control: nil,
+              sequence_number: 0,
+              blob_type: 'PageBlob',
+              copy_id: '095adc3b-e277-4c3d-97e0-0abca881f60c',
+              copy_status: 'success',
+              copy_source: 'https://testaccount.blob.core.windows.net/testblob/4m?snapshot=2016-02-04T08%3A35%3A50.3157696Z',
+              copy_progress: '4194304/4194304',
+              copy_completion_time: 'Thu, 04 Feb 2016 08:35:52 GMT',
+              copy_status_description: nil,
+              accept_ranges: 0
             }
           blob
         end

--- a/lib/fog/azurerm/requests/storage/get_blob_properties.rb
+++ b/lib/fog/azurerm/requests/storage/get_blob_properties.rb
@@ -25,28 +25,28 @@ module Fog
           blob.name = 'test_blob'
           blob.metadata = {}
           blob.properties = {
-              last_modified: 'Mon, 04 Jul 2016 09:30:31 GMT',
-              etag: '0x8D3A3EDD7C2B777',
-              lease_status: 'unlocked',
-              lease_state: 'available',
-              lease_duration: nil,
-              content_length: 4_194_304,
-              content_type: 'application/octet-stream',
-              content_encoding: nil,
-              content_language: nil,
-              content_disposition: nil,
-              content_md5: 'tXAohIyxuu/t94Lp/ujeRw==',
-              cache_control: nil,
-              sequence_number: 0,
-              blob_type: 'PageBlob',
-              copy_id: '095adc3b-e277-4c3d-97e0-0abca881f60c',
-              copy_status: 'success',
-              copy_source: 'https://testaccount.blob.core.windows.net/testblob/4m?snapshot=2016-02-04T08%3A35%3A50.3157696Z',
-              copy_progress: '4194304/4194304',
-              copy_completion_time: 'Thu, 04 Feb 2016 08:35:52 GMT',
-              copy_status_description: nil,
-              accept_ranges: 0
-            }
+            last_modified: 'Mon, 04 Jul 2016 09:30:31 GMT',
+            etag: '0x8D3A3EDD7C2B777',
+            lease_status: 'unlocked',
+            lease_state: 'available',
+            lease_duration: nil,
+            content_length: 4_194_304,
+            content_type: 'application/octet-stream',
+            content_encoding: nil,
+            content_language: nil,
+            content_disposition: nil,
+            content_md5: 'tXAohIyxuu/t94Lp/ujeRw==',
+            cache_control: nil,
+            sequence_number: 0,
+            blob_type: 'PageBlob',
+            copy_id: '095adc3b-e277-4c3d-97e0-0abca881f60c',
+            copy_status: 'success',
+            copy_source: 'https://testaccount.blob.core.windows.net/testblob/4m?snapshot=2016-02-04T08%3A35%3A50.3157696Z',
+            copy_progress: '4194304/4194304',
+            copy_completion_time: 'Thu, 04 Feb 2016 08:35:52 GMT',
+            copy_status_description: nil,
+            accept_ranges: 0
+          }
           blob
         end
       end

--- a/lib/fog/azurerm/storage.rb
+++ b/lib/fog/azurerm/storage.rb
@@ -77,6 +77,7 @@ module Fog
         def initialize(_options = {})
           begin
             require 'azure_mgmt_storage'
+            require 'azure/storage'
           rescue LoadError => e
             retry if require('rubygems')
             raise e.message

--- a/test/api_stub/requests/storage/file.rb
+++ b/test/api_stub/requests/storage/file.rb
@@ -9,9 +9,6 @@ module ApiStub
           blob = Azure::Storage::Blob::Blob.new
           blob.name = blob_data['name']
           blob.metadata = blob_data['metadata']
-          # properties = {}
-          # blob_data['properties'].keys.each { |key| properties[key.to_sym] = blob_data['properties'][key] }
-          # blob.properties = properties
           blob.properties = blob_data['properties'].map { |k, v| { k.to_sym => v } }.reduce({}, &:merge!)
           blob
         end

--- a/test/api_stub/requests/storage/file.rb
+++ b/test/api_stub/requests/storage/file.rb
@@ -5,6 +5,15 @@ module ApiStub
       # Below data should be as same as those in Mock classes in lib/fog/azurerm/requests/storage/*.rb
       class File
         def self.blob
+          blob_data = blob_as_hash
+          blob = Azure::Storage::Blob::Blob.new
+          blob.name = blob_data['name']
+          blob.metadata = blob_data['metadata']
+          blob.properties = blob_data['properties']
+          blob
+        end
+
+        def self.blob_as_hash
           {
             'name' => 'test_blob',
             'metadata' => {},

--- a/test/api_stub/requests/storage/file.rb
+++ b/test/api_stub/requests/storage/file.rb
@@ -9,7 +9,10 @@ module ApiStub
           blob = Azure::Storage::Blob::Blob.new
           blob.name = blob_data['name']
           blob.metadata = blob_data['metadata']
-          blob.properties = blob_data['properties']
+          # properties = {}
+          # blob_data['properties'].keys.each { |key| properties[key.to_sym] = blob_data['properties'][key] }
+          # blob.properties = properties
+          blob.properties = blob_data['properties'].map { |k,v| { k.to_sym => v } }.reduce({}, &:merge!)
           blob
         end
 

--- a/test/api_stub/requests/storage/file.rb
+++ b/test/api_stub/requests/storage/file.rb
@@ -12,7 +12,7 @@ module ApiStub
           # properties = {}
           # blob_data['properties'].keys.each { |key| properties[key.to_sym] = blob_data['properties'][key] }
           # blob.properties = properties
-          blob.properties = blob_data['properties'].map { |k,v| { k.to_sym => v } }.reduce({}, &:merge!)
+          blob.properties = blob_data['properties'].map { |k, v| { k.to_sym => v } }.reduce({}, &:merge!)
           blob
         end
 

--- a/test/requests/storage/test_get_blob.rb
+++ b/test/requests/storage/test_get_blob.rb
@@ -13,7 +13,7 @@ class TestGetBlob < Minitest::Test
     @blob_client = @service.instance_variable_get(:@blob_client)
 
     @raw_cloud_blob = storage_blob
-    @blob = ApiStub::Requests::Storage::File.blob
+    @blob = ApiStub::Requests::Storage::File.blob_as_hash
     @blob_with_content = [
       @blob,
       'content'

--- a/test/requests/storage/test_get_blob_properties.rb
+++ b/test/requests/storage/test_get_blob_properties.rb
@@ -40,6 +40,8 @@ class TestGetBlobProperties < Minitest::Test
   end
 
   def test_get_blob_properties_mock
-    assert_equal @blob, @mock_service.get_blob_properties('test_container', 'test_blob')
+    mock_blob_properties = @mock_service.get_blob_properties('test_container', 'test_blob')
+    assert_equal @blob.name, mock_blob_properties.name
+    assert_equal @blob.properties, mock_blob_properties.properties
   end
 end


### PR DESCRIPTION
Fixes #387.

Return an Azure::Storage::Blob::Blob from `get_blob_properties` instead of a Hash.