### PR TITLE
Fix/virtual machine extension all

### DIFF
--- a/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
+++ b/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
@@ -10,7 +10,7 @@ module Fog
         def all
           requires :resource_group, :vm_name
           vm_extensions = []
-          service.get_virtual_machine(resource_group, vm_name).resources.compact.each do |extension|
+          service.get_virtual_machine(resource_group, vm_name, false).resources.compact.each do |extension|
             vm_extensions << Fog::Compute::AzureRM::VirtualMachineExtension.parse(extension)
           end
           load(vm_extensions)

--- a/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
+++ b/lib/fog/azurerm/models/compute/virtual_machine_extensions.rb
@@ -10,7 +10,9 @@ module Fog
         def all
           requires :resource_group, :vm_name
           vm_extensions = []
-          service.get_virtual_machine(resource_group, vm_name, false).resources.compact.each do |extension|
+          resources = service.get_virtual_machine(resource_group, vm_name, false).resources
+          return vm_extensions unless resources
+          resources.compact.each do |extension|
             vm_extensions << Fog::Compute::AzureRM::VirtualMachineExtension.parse(extension)
           end
           load(vm_extensions)


### PR DESCRIPTION
Hi !

This PR fix two bug on virtual_machine_extensions#all:
- `get_virtual_machine` take tree params now (the new one is `async`)
- `get_virtual_machine(..).resources` can be nil

Thanks in advance for your time