### PR TITLE
Fixed Bundler Gem Version for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 sudo: false
 
 before_install:
-  - gem install bundler
-  - gem update bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
   - gem uninstall -aIx nokogiri -i /home/travis/.rvm/gems/ruby-2.4.1@global nokogiri
 
 script: bash ./rake-script.sh


### PR DESCRIPTION
The version for the `bundler` gem has been locked to `< 2.x` in the `.travis.yml` which is the last version supported on `Ruby 2.0`