### PR TITLE
Updated List Method for Network Security Groups

### DIFF
--- a/lib/fog/azurerm/requests/network/list_network_security_groups.rb
+++ b/lib/fog/azurerm/requests/network/list_network_security_groups.rb
@@ -8,160 +8,156 @@ module Fog
           Fog::Logger.debug msg
 
           begin
-            nsg_list_result = @network_client.network_security_groups.list_as_lazy(resource_group)
+            nsg_list_result = @network_client.network_security_groups.list(resource_group)
           rescue MsRestAzure::AzureOperationError => e
             raise_azure_exception(e, msg)
           end
 
           Fog::Logger.debug "Network Security Groups list retrieved successfully from Resource Group #{resource_group}."
-          nsg_list_result.value
+          nsg_list_result
         end
       end
 
       # Mock class for Network Request
       class Mock
         def list_network_security_groups(resource_group)
-          nsg_list_result = {
-            'value' => [
-              {
-                'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup",
-                'name' => 'testGroup',
-                'type' => 'Microsoft.Network/networkSecurityGroups',
-                'location' => 'westus',
-                'properties' =>
-                  {
-                    'securityRules' =>
-                      [
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/securityRules/testRule",
-                          'properties' =>
-                            {
-                              'protocol' => 'tcp',
-                              'sourceAddressPrefix' => '0.0.0.0/0',
-                              'destinationAddressPrefix' => '0.0.0.0/0',
-                              'access' => 'Allow',
-                              'direction' => 'Inbound',
-                              'sourcePortRange' => '22',
-                              'destinationPortRange' => '22',
-                              'priority' => 100,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'testRule'
-                        }
-                      ],
-                    'defaultSecurityRules' =>
-                      [
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowVnetInBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => 'VirtualNetwork',
-                              'destinationAddressPrefix' => 'VirtualNetwork',
-                              'access' => 'Allow',
-                              'direction' => 'Inbound',
-                              'description' => 'Allow inbound traffic from all VMs in VNET',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_000,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'AllowVnetInBound'
-                        },
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => 'AzureLoadBalancer',
-                              'destinationAddressPrefix' => '*',
-                              'access' => 'Allow',
-                              'direction' => 'Inbound',
-                              'description' => 'Allow inbound traffic from azure load balancer',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_001,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'AllowAzureLoadBalancerInBound'
-                        },
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/DenyAllInBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => '*',
-                              'destinationAddressPrefix' => '*',
-                              'access' => 'Deny',
-                              'direction' => 'Inbound',
-                              'description' => 'Deny all inbound traffic',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_500,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'DenyAllInBound'
-                        },
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowVnetOutBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => 'VirtualNetwork',
-                              'destinationAddressPrefix' => 'VirtualNetwork',
-                              'access' => 'Allow',
-                              'direction' => 'Outbound',
-                              'description' => 'Allow outbound traffic from all VMs to all VMs in VNET',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_000,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'AllowVnetOutBound'
-                        },
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowInternetOutBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => '*',
-                              'destinationAddressPrefix' => 'Internet',
-                              'access' => 'Allow',
-                              'direction' => 'Outbound',
-                              'description' => 'Allow outbound traffic from all VMs to Internet',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_001,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'AllowInternetOutBound'
-                        },
-                        {
-                          'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/DenyAllOutBound",
-                          'properties' =>
-                            {
-                              'protocol' => '*',
-                              'sourceAddressPrefix' => '*',
-                              'destinationAddressPrefix' => '*',
-                              'access' => 'Deny',
-                              'direction' => 'Outbound',
-                              'description' => 'Deny all outbound traffic',
-                              'sourcePortRange' => '*',
-                              'destinationPortRange' => '*',
-                              'priority' => 65_500,
-                              'provisioningState' => 'Succeeded'
-                            },
-                          'name' => 'DenyAllOutBound'
-                        }
-                      ],
-                    'resourceGuid' => '9dca97e6-4789-4ebd-86e3-52b8b0da6cd4',
-                    'provisioningState' => 'Succeeded'
-                  }
-              }
-            ]
-          }
-          nsg_mapper = Azure::ARM::Network::Models::NetworkInterfaceListResult.mapper
-          @network_client.deserialize(nsg_mapper, nsg_list_result, 'result.body').value
+          [
+            {
+              'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup",
+              'name' => 'testGroup',
+              'type' => 'Microsoft.Network/networkSecurityGroups',
+              'location' => 'westus',
+              'properties' =>
+                {
+                  'securityRules' =>
+                    [
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/securityRules/testRule",
+                        'properties' =>
+                          {
+                            'protocol' => 'tcp',
+                            'sourceAddressPrefix' => '0.0.0.0/0',
+                            'destinationAddressPrefix' => '0.0.0.0/0',
+                            'access' => 'Allow',
+                            'direction' => 'Inbound',
+                            'sourcePortRange' => '22',
+                            'destinationPortRange' => '22',
+                            'priority' => 100,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'testRule'
+                      }
+                    ],
+                  'defaultSecurityRules' =>
+                    [
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowVnetInBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => 'VirtualNetwork',
+                            'destinationAddressPrefix' => 'VirtualNetwork',
+                            'access' => 'Allow',
+                            'direction' => 'Inbound',
+                            'description' => 'Allow inbound traffic from all VMs in VNET',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_000,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'AllowVnetInBound'
+                      },
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => 'AzureLoadBalancer',
+                            'destinationAddressPrefix' => '*',
+                            'access' => 'Allow',
+                            'direction' => 'Inbound',
+                            'description' => 'Allow inbound traffic from azure load balancer',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_001,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'AllowAzureLoadBalancerInBound'
+                      },
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/DenyAllInBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => '*',
+                            'destinationAddressPrefix' => '*',
+                            'access' => 'Deny',
+                            'direction' => 'Inbound',
+                            'description' => 'Deny all inbound traffic',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_500,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'DenyAllInBound'
+                      },
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowVnetOutBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => 'VirtualNetwork',
+                            'destinationAddressPrefix' => 'VirtualNetwork',
+                            'access' => 'Allow',
+                            'direction' => 'Outbound',
+                            'description' => 'Allow outbound traffic from all VMs to all VMs in VNET',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_000,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'AllowVnetOutBound'
+                      },
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/AllowInternetOutBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => '*',
+                            'destinationAddressPrefix' => 'Internet',
+                            'access' => 'Allow',
+                            'direction' => 'Outbound',
+                            'description' => 'Allow outbound traffic from all VMs to Internet',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_001,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'AllowInternetOutBound'
+                      },
+                      {
+                        'id' => "/subscriptions/########-####-####-####-############/resourceGroups/#{resource_group}/providers/Microsoft.Network/networkSecurityGroups/testGroup/defaultSecurityRules/DenyAllOutBound",
+                        'properties' =>
+                          {
+                            'protocol' => '*',
+                            'sourceAddressPrefix' => '*',
+                            'destinationAddressPrefix' => '*',
+                            'access' => 'Deny',
+                            'direction' => 'Outbound',
+                            'description' => 'Deny all outbound traffic',
+                            'sourcePortRange' => '*',
+                            'destinationPortRange' => '*',
+                            'priority' => 65_500,
+                            'provisioningState' => 'Succeeded'
+                          },
+                        'name' => 'DenyAllOutBound'
+                      }
+                    ],
+                  'resourceGuid' => '9dca97e6-4789-4ebd-86e3-52b8b0da6cd4',
+                  'provisioningState' => 'Succeeded'
+                }
+            }
+          ]
         end
       end
     end

--- a/test/api_stub/requests/network/network_security_group.rb
+++ b/test/api_stub/requests/network/network_security_group.rb
@@ -216,8 +216,8 @@ module ApiStub
              }
             ]
           }'
-          result_mapper = Azure::ARM::Network::Models::NetworkInterfaceListResult.mapper
-          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg_list), 'result.body')
+          result_mapper = Azure::ARM::Network::Models::NetworkSecurityGroupListResult.mapper
+          network_client.deserialize(result_mapper, Fog::JSON.decode(nsg_list), 'result.body').value
         end
       end
     end

--- a/test/requests/network/test_list_network_security_groups.rb
+++ b/test/requests/network/test_list_network_security_groups.rb
@@ -10,14 +10,14 @@ class TestListNetworkSecurityGroup < Minitest::Test
 
   def test_list_network_security_group_success
     mocked_response = ApiStub::Requests::Network::NetworkSecurityGroup.list_network_security_group_response(@client)
-    @network_security_groups.stub :list_as_lazy, mocked_response do
-      assert_equal @service.list_network_security_groups('fog-test-rg'), mocked_response.value
+    @network_security_groups.stub :list, mocked_response do
+      assert_equal @service.list_network_security_groups('fog-test-rg'), mocked_response
     end
   end
 
   def test_list_network_security_group_failure
     response = proc { raise MsRestAzure::AzureOperationError.new(nil, nil, 'error' => { 'message' => 'mocked exception' }) }
-    @network_security_groups.stub :list_as_lazy, response do
+    @network_security_groups.stub :list, response do
       assert_raises MsRestAzure::AzureOperationError do
         @service.list_network_security_groups('fog-test-rg')
       end


### PR DESCRIPTION
Summary: The list method for network security groups was using the 'list_as_lazy' method which was not handling pagination by default. It has been replaced with the 'list' method that returns all the results even if they are divided into pages. The unit tests and mocks have been updated accordingly as well.