### PR TITLE
Removed Deprecated Badge 'Gemnasium' and Unused Badge 'Waffle'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 [![Gem Version](https://badge.fury.io/rb/fog-azure-rm.svg)](https://badge.fury.io/rb/fog-azure-rm)
 [![Build Status](https://travis-ci.org/fog/fog-azure-rm.svg?branch=master)](https://travis-ci.org/fog/fog-azure-rm)
-[![Dependency Status](https://gemnasium.com/badges/github.com/fog/fog-azure-rm.svg)](https://gemnasium.com/github.com/fog/fog-azure-rm)
+[![security](https://hakiri.io/github/fog/fog-azure-rm/master.svg)](https://hakiri.io/github/fog/fog-azure-rm/master)
 [![Test Coverage](https://codeclimate.com/github/fog/fog-azure-rm/badges/coverage.svg)](https://codeclimate.com/github/fog/fog-azure-rm/coverage)
 [![Code Climate](https://codeclimate.com/github/fog/fog-azure-rm/badges/gpa.svg)](https://codeclimate.com/github/fog/fog-azure-rm)
-[![Stories in Ready](https://badge.waffle.io/fog/fog-azure-rm.svg?label=ready&title=Ready)](http://waffle.io/fog/fog-azure-rm)
 
 # Fog Azure Resource Manager
 


### PR DESCRIPTION
Summary: The unused third party integration services such as `Gemnasium` and `Waffle` have been removed as `Gemnasium` is now deprecated and `Waffle` is no longer needed.
In place of `Gemnasium` we have added a new badge for `Hakiri` for monitoring security threats in gem dependencies.

Differential Revision: https://phabricator.confiz.com/D12845