### PR TITLE
Added Async Create Call for Network Interface

### DIFF
--- a/lib/fog/azurerm/docs/network.md
+++ b/lib/fog/azurerm/docs/network.md
@@ -261,6 +261,24 @@ nic = fog_network_service.network_interfaces.create(
 )
 ```
 
+## Create Network Interface Card Asynchronously
+
+Create a new network interface asynchronously. Skip public_ip_address_id parameter to create network interface without PublicIP. The parameter, private_ip_allocation_method can be Dynamic or Static.
+
+```ruby
+nic = fog_network_service.network_interfaces.create_async(
+      name: '<Network Interface Name>',
+      resource_group: '<Resource Group Name>',
+      location: '<Location>',
+      subnet_id: '/subscriptions/<Subscription Id>/resourceGroups/<Resource Group Name>/providers/Microsoft.Network/virtualNetworks/<Virtual Network Name>/subnets/<Subnet Name>',
+      public_ip_address_id: '/subscriptions/<Subscription Id>/resourceGroups/<Resource Group Name>/providers/Microsoft.Network/publicIPAddresses/<Public IP Name>',
+      ip_configuration_name: '<IP Configuration Name>',
+      private_ip_allocation_method: '<IP Allocation Method Name>',
+      tags: { key: 'value' }                    # [Optional],
+      enable_accelerated_networking: true       # [Optional] false by default
+)
+```
+
 ## List Network Interface Cards
 
 List network interfaces in a resource group

--- a/lib/fog/azurerm/models/network/network_interface.rb
+++ b/lib/fog/azurerm/models/network/network_interface.rb
@@ -59,15 +59,21 @@ module Fog
           hash
         end
 
-        def save
+        def save(async = false)
           requires :name
           requires :location
           requires :resource_group
           requires :subnet_id
           requires :ip_configuration_name
           requires :private_ip_allocation_method
-          nic = service.create_or_update_network_interface(resource_group, name, location, subnet_id, public_ip_address_id, network_security_group_id, ip_configuration_name, private_ip_allocation_method, private_ip_address, load_balancer_backend_address_pools_ids, load_balancer_inbound_nat_rules_ids, tags, enable_accelerated_networking)
-          merge_attributes(Fog::Network::AzureRM::NetworkInterface.parse(nic))
+
+          nic_response = service.create_or_update_network_interface(resource_group, name, location, subnet_id, public_ip_address_id, network_security_group_id, ip_configuration_name, private_ip_allocation_method, private_ip_address, load_balancer_backend_address_pools_ids, load_balancer_inbound_nat_rules_ids, tags, enable_accelerated_networking, async)
+
+          if async
+            nic_response
+          else
+            merge_attributes(Fog::Network::AzureRM::NetworkInterface.parse(nic_response))
+          end
         end
 
         def update(updated_attributes = {})

--- a/lib/fog/azurerm/models/network/network_interfaces.rb
+++ b/lib/fog/azurerm/models/network/network_interfaces.rb
@@ -15,6 +15,12 @@ module Fog
           load(network_interfaces)
         end
 
+        def create_async(attributes = {})
+          network_interface = new(attributes)
+          promise = network_interface.save(true)
+          Fog::AzureRM::AsyncResponse.new(network_interface, promise)
+        end
+
         def get(resource_group_name, name)
           network_interface_card = service.get_network_interface(resource_group_name, name)
           network_interface_card_fog = Fog::Network::AzureRM::NetworkInterface.new(service: service)

--- a/lib/fog/azurerm/requests/network/create_or_update_network_interface.rb
+++ b/lib/fog/azurerm/requests/network/create_or_update_network_interface.rb
@@ -4,17 +4,21 @@ module Fog
     class AzureRM
       # Real class for Network Request
       class Real
-        def create_or_update_network_interface(resource_group_name, name, location, subnet_id, public_ip_address_id, network_security_group_id, ip_config_name, private_ip_allocation_method, private_ip_address, load_balancer_backend_address_pools_ids, load_balancer_inbound_nat_rules_ids, tags, enable_accelerated_networking = false)
+        def create_or_update_network_interface(resource_group_name, name, location, subnet_id, public_ip_address_id, network_security_group_id, ip_config_name, private_ip_allocation_method, private_ip_address, load_balancer_backend_address_pools_ids, load_balancer_inbound_nat_rules_ids, tags, enable_accelerated_networking = false, async = false)
           msg = "Creating/Updating Network Interface Card: #{name}"
           Fog::Logger.debug msg
           network_interface = get_network_interface_object(name, location, subnet_id, public_ip_address_id, network_security_group_id, ip_config_name, private_ip_allocation_method, private_ip_address, load_balancer_backend_address_pools_ids, load_balancer_inbound_nat_rules_ids, tags, enable_accelerated_networking)
           begin
-            network_interface_obj = @network_client.network_interfaces.create_or_update(resource_group_name, name, network_interface)
+            nic_response = if async
+                             @network_client.network_interfaces.create_or_update_async(resource_group_name, name, network_interface)
+                           else
+                             @network_client.network_interfaces.create_or_update(resource_group_name, name, network_interface)
+                           end
           rescue MsRestAzure::AzureOperationError => e
             raise_azure_exception(e, msg)
           end
-          Fog::Logger.debug "Network Interface #{name} created/updated successfully."
-          network_interface_obj
+          Fog::Logger.debug "Network Interface #{name} created/updated successfully." unless async
+          nic_response
         end
 
         private

--- a/test/requests/network/test_create_network_interface.rb
+++ b/test/requests/network/test_create_network_interface.rb
@@ -14,12 +14,22 @@ class TestCreateNetworkInterface < Minitest::Test
     @network_interfaces.stub :create_or_update, mocked_response do
       assert_equal @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags), mocked_response
     end
+
+    # Async
+    @network_interfaces.stub :create_or_update_async, mocked_response do
+      assert_equal @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags, false, true), mocked_response
+    end
   end
 
   def test_create_network_interface_without_public_ip_success
     mocked_response = ApiStub::Requests::Network::NetworkInterface.create_network_interface_response(@network_client)
     @network_interfaces.stub :create_or_update, mocked_response do
       assert_equal @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', nil, 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags), mocked_response
+    end
+
+    # Async
+    @network_interfaces.stub :create_or_update_async, mocked_response do
+      assert_equal @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', nil, 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags, false, true), mocked_response
     end
   end
 
@@ -30,6 +40,13 @@ class TestCreateNetworkInterface < Minitest::Test
         @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', ['id-1', 'id-2'], ['id-1', 'id-2'])
       end
     end
+
+    # Async
+    @network_interfaces.stub :create_or_update_async, response do
+      assert_raises ArgumentError do
+        @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', ['id-1', 'id-2'], ['id-1', 'id-2'], false, true)
+      end
+    end
   end
 
   def test_create_network_interface_exception_failure
@@ -37,6 +54,13 @@ class TestCreateNetworkInterface < Minitest::Test
     @network_interfaces.stub :create_or_update, response do
       assert_raises MsRestAzure::AzureOperationError do
         @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags)
+      end
+    end
+
+    # Async
+    @network_interfaces.stub :create_or_update_async, response do
+      assert_raises MsRestAzure::AzureOperationError do
+        @service.create_or_update_network_interface('fog-test-rg', 'fog-test-network-interface', 'West US', 'fog-test-subnet-id', 'fog-test-ip-address-id', 'fog-test-nsg-id', 'fog-test-ip-configuration', 'Dynamic', '10.0.0.8', ['id-1', 'id-2'], ['id-1', 'id-2'], @tags, false, true)
       end
     end
   end


### PR DESCRIPTION
The Network Interface Card can now be created via an Async call as well. 
Respective unit tests and integration tests have been updated as well.
