### PR TITLE
Added Caching Option for Managed Disk

### DIFF
--- a/lib/fog/azurerm/docs/compute.md
+++ b/lib/fog/azurerm/docs/compute.md
@@ -310,10 +310,10 @@ fog_compute_service.managed_disks.create(
 
 ## Attach a Managed Data Disk to Server
 
-Get the server object and attach a Data Disk with Disk Caching Type to it. Possible <Disk Caching Type> values include: "None", "ReadOnly", "ReadWrite". By Default "None" set.
+Get the server object and attach a Data Disk with Disk Caching Option to it. Possible <Disk Caching Option> values include: "None", "ReadOnly", "ReadWrite". By Default "None" set.
 
 ```ruby
-server.attach_managed_disk('<Disk Name>', '<Disk Resource Group Name>', '<Disk Caching Type>')
+server.attach_managed_disk('<Disk Name>', '<Disk Resource Group Name>', '<Async Option>', '<Disk Caching Option>')
 ```
 
 ## Detach a Managed Data Disk from Server

--- a/lib/fog/azurerm/docs/compute.md
+++ b/lib/fog/azurerm/docs/compute.md
@@ -160,7 +160,7 @@ async_response = fog_compute_service.servers.create_async(
         os_disk_name: '<Disk Name>'                          # [Optional], name of the os disk
 )
 ```
-Following methods are available to handle async respoonse:
+Following methods are available to handle async response:
 - state
 - pending?
 - rejected?
@@ -310,10 +310,10 @@ fog_compute_service.managed_disks.create(
 
 ## Attach a Managed Data Disk to Server
 
-Get the server object and attach a Data Disk to it.
+Get the server object and attach a Data Disk with Disk Caching Type to it. Possible <Disk Caching Type> values include: "None", "ReadOnly", "ReadWrite". By Default "None" set.
 
 ```ruby
-server.attach_managed_disk('<Disk Name>', '<Disk Resource Group Name>')
+server.attach_managed_disk('<Disk Name>', '<Disk Resource Group Name>', '<Disk Caching Type>')
 ```
 
 ## Detach a Managed Data Disk from Server

--- a/lib/fog/azurerm/models/compute/server.rb
+++ b/lib/fog/azurerm/models/compute/server.rb
@@ -173,7 +173,7 @@ module Fog
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end
 
-        def attach_managed_disk(disk_name, disk_resource_group, caching = 'None', async = false)
+        def attach_managed_disk(disk_name, disk_resource_group, async = false, caching = 'None')
           response = service.attach_data_disk_to_vm(data_disk_params(disk_name, nil, nil, disk_resource_group, caching), async)
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end

--- a/lib/fog/azurerm/models/compute/server.rb
+++ b/lib/fog/azurerm/models/compute/server.rb
@@ -173,8 +173,8 @@ module Fog
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end
 
-        def attach_managed_disk(disk_name, disk_resource_group, async = false)
-          response = service.attach_data_disk_to_vm(data_disk_params(disk_name, nil, nil, disk_resource_group), async)
+        def attach_managed_disk(disk_name, disk_resource_group, async = false, caching = 'None')
+          response = service.attach_data_disk_to_vm(data_disk_params(disk_name, nil, nil, disk_resource_group), async, caching)
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end
 

--- a/lib/fog/azurerm/models/compute/server.rb
+++ b/lib/fog/azurerm/models/compute/server.rb
@@ -173,8 +173,8 @@ module Fog
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end
 
-        def attach_managed_disk(disk_name, disk_resource_group, async = false, caching = 'None')
-          response = service.attach_data_disk_to_vm(data_disk_params(disk_name, nil, nil, disk_resource_group), async, caching)
+        def attach_managed_disk(disk_name, disk_resource_group, caching = 'None', async = false)
+          response = service.attach_data_disk_to_vm(data_disk_params(disk_name, nil, nil, disk_resource_group, caching), async)
           async ? create_fog_async_response(response) : merge_attributes(Fog::Compute::AzureRM::Server.parse(response))
         end
 
@@ -239,14 +239,15 @@ module Fog
           }
         end
 
-        def data_disk_params(disk_name, disk_size = nil, storage_account = nil, disk_resource_group = nil)
+        def data_disk_params(disk_name, disk_size = nil, storage_account = nil, disk_resource_group = nil, caching = nil)
           {
             vm_name: name,
             vm_resource_group: resource_group,
             disk_name: disk_name,
             disk_size_gb: disk_size,
             storage_account_name: storage_account,
-            disk_resource_group: disk_resource_group
+            disk_resource_group: disk_resource_group,
+            caching: caching
           }
         end
 

--- a/lib/fog/azurerm/requests/compute/attach_data_disk_to_vm.rb
+++ b/lib/fog/azurerm/requests/compute/attach_data_disk_to_vm.rb
@@ -11,7 +11,7 @@ module Fog
           disk_resource_group = disk_params[:disk_resource_group]
           disk_size = disk_params[:disk_size_gb]
           storage_account_name = disk_params[:storage_account_name]
-          caching = disk_params[:caching] || 'None'
+          caching = disk_params[:caching] || nil
 
           msg = "Attaching Data Disk #{disk_name} to Virtual Machine #{vm_name} in Resource Group #{vm_resource_group}"
           Fog::Logger.debug msg
@@ -95,8 +95,10 @@ module Fog
                                    Azure::ARM::Compute::Models::CachingTypes::ReadOnly
                                  when 'ReadWrite'
                                    Azure::ARM::Compute::Models::CachingTypes::ReadWrite
-                                 else
+                                 when 'None', nil
                                    Azure::ARM::Compute::Models::CachingTypes::None
+                                 else
+                                   raise "Invalid Disk Caching Option: #{caching}"
                                  end
 
           # Managed disk parameter

--- a/test/integration/credentials/azure.yml
+++ b/test/integration/credentials/azure.yml
@@ -1,5 +1,5 @@
-client_id: 438db273-03ec-4216-bb5c-c5bbefc30002 
-client_secret: 3HtGStUygp66/9+aUzhYhJnltwFaWYo+DrdRWLCNUAc= 
-subscription_id: 8339d243-d139-4e55-addf-e94fd402d8ff 
-tenant_id: 3fd2b764-62b9-47eb-89a0-af099ce11c48 
-environment: 
+client_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+subscription_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+tenant_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+environment: XXXXXXXX

--- a/test/integration/credentials/azure.yml
+++ b/test/integration/credentials/azure.yml
@@ -1,5 +1,5 @@
-client_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-client_secret: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-subscription_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-tenant_id: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-environment: XXXXXXXX
+client_id: 438db273-03ec-4216-bb5c-c5bbefc30002 
+client_secret: 3HtGStUygp66/9+aUzhYhJnltwFaWYo+DrdRWLCNUAc= 
+subscription_id: 8339d243-d139-4e55-addf-e94fd402d8ff 
+tenant_id: 3fd2b764-62b9-47eb-89a0-af099ce11c48 
+environment: 

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -269,10 +269,10 @@ begin
   managed_vm.attach_managed_disk('ManagedDataDisk', 'TestRG-VM')
   puts 'Attached Managed Data Disk to VM!'
 
-  managed_vm.attach_managed_disk('ManagedDataDiskRO', 'TestRG-VM', 'ReadOnly')
+  managed_vm.attach_managed_disk('ManagedDataDiskRO', 'TestRG-VM', false, 'ReadOnly')
   puts 'Attached Managed Data Disk with Disk Caching ReadOnly to VM!'
 
-  managed_vm.attach_managed_disk('ManagedDataDiskRW', 'TestRG-VM', 'ReadWrite')
+  managed_vm.attach_managed_disk('ManagedDataDiskRW', 'TestRG-VM', false, 'ReadWrite')
   puts 'Attached Managed Data Disk with Disk Caching ReadWrite to VM!'
 
   ########################################################################################################################

--- a/test/integration/server.rb
+++ b/test/integration/server.rb
@@ -7,7 +7,7 @@ require 'yaml'
 ########################################################################################################################
 
 azure_credentials = YAML.load_file(File.expand_path('credentials/azure.yml', __dir__))
-puts azure_credentials
+
 rs = Fog::Resources::AzureRM.new(
   tenant_id: azure_credentials['tenant_id'],
   client_id: azure_credentials['client_id'],
@@ -261,6 +261,7 @@ begin
     }
   )
   puts "Created Managed Disk: #{managed_disk_rw.name}"
+
   ########################################################################################################################
   ######################                          Attach Managed Data Disk to VM                    ######################
   ########################################################################################################################
@@ -268,11 +269,11 @@ begin
   managed_vm.attach_managed_disk('ManagedDataDisk', 'TestRG-VM')
   puts 'Attached Managed Data Disk to VM!'
 
-  managed_vm.attach_managed_disk('ManagedDataDiskRO', 'TestRG-VM', false, 'ReadOnly')
-  puts 'Attached Managed Data Disk ReadOnly to VM!'
+  managed_vm.attach_managed_disk('ManagedDataDiskRO', 'TestRG-VM', 'ReadOnly')
+  puts 'Attached Managed Data Disk with Disk Caching ReadOnly to VM!'
 
-  managed_vm.attach_managed_disk('ManagedDataDiskRW', 'TestRG-VM', false, 'ReadWrite')
-  puts 'Attached Managed Data Disk ReadWrite to VM!'
+  managed_vm.attach_managed_disk('ManagedDataDiskRW', 'TestRG-VM', 'ReadWrite')
+  puts 'Attached Managed Data Disk with Disk Caching ReadWrite to VM!'
 
   ########################################################################################################################
   ######################                          Detach Data Disk from VM                          ######################
@@ -282,10 +283,10 @@ begin
   puts 'Detached Managed Data Disk from VM!'
 
   managed_vm.detach_managed_disk('ManagedDataDiskRO')
-  puts 'Detached Managed Data Disk ReadOnly from VM!'
+  puts 'Detached Managed Data Disk with Disk Caching ReadOnly from VM!'
 
   managed_vm.detach_managed_disk('ManagedDataDiskRW')
-  puts 'Detached Managed Data Disk ReadWrite from VM!'
+  puts 'Detached Managed Data Disk with Disk Caching ReadWrite from VM!'
 
   ########################################################################################################################
   ######################                         Delete Managed Data Disk                           ######################
@@ -295,10 +296,10 @@ begin
   puts 'Deleted managed data disk!'
 
   managed_disk_ro.destroy
-  puts 'Deleted managed data disk ReadOnly!'
+  puts 'Deleted managed data disk with Disk Caching ReadOnly!'
 
   managed_disk_rw.destroy
-  puts 'Deleted managed data disk ReadWrite!'
+  puts 'Deleted managed data disk with Disk Caching ReadWrite!'
 
   ########################################################################################################################
   ######################                      List VM in a resource group                           ######################

--- a/test/models/compute/test_server.rb
+++ b/test/models/compute/test_server.rb
@@ -217,15 +217,15 @@ class TestServer < Minitest::Test
       assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group')
     end
     @service.stub :attach_data_disk_to_vm, response do
-      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', 'ReadOnly')
+      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', false, 'ReadOnly')
     end
     @service.stub :attach_data_disk_to_vm, response do
-      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', 'ReadWrite')
+      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', false, 'ReadWrite')
     end
 
     async_response = Concurrent::Promise.execute { 10 }
     @service.stub :attach_data_disk_to_vm, async_response do
-      assert_instance_of Fog::AzureRM::AsyncResponse, @server.attach_managed_disk('managed_disk_name', 'resoure_group', nil, true)
+      assert_instance_of Fog::AzureRM::AsyncResponse, @server.attach_managed_disk('managed_disk_name', 'resoure_group', true)
     end
   end
 

--- a/test/models/compute/test_server.rb
+++ b/test/models/compute/test_server.rb
@@ -216,10 +216,16 @@ class TestServer < Minitest::Test
     @service.stub :attach_data_disk_to_vm, response do
       assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group')
     end
+    @service.stub :attach_data_disk_to_vm, response do
+      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', 'ReadOnly')
+    end
+    @service.stub :attach_data_disk_to_vm, response do
+      assert_instance_of Fog::Compute::AzureRM::Server, @server.attach_managed_disk('disk_name', 'resoure_group', 'ReadWrite')
+    end
 
     async_response = Concurrent::Promise.execute { 10 }
     @service.stub :attach_data_disk_to_vm, async_response do
-      assert_instance_of Fog::AzureRM::AsyncResponse, @server.attach_managed_disk('managed_disk_name', 'resoure_group', true)
+      assert_instance_of Fog::AzureRM::AsyncResponse, @server.attach_managed_disk('managed_disk_name', 'resoure_group', nil, true)
     end
   end
 

--- a/test/requests/compute/test_attach_data_disk_to_vm.rb
+++ b/test/requests/compute/test_attach_data_disk_to_vm.rb
@@ -45,16 +45,16 @@ class TestAttachDataDiskToVM < Minitest::Test
     @virtual_machines.stub :get, @get_vm_response do
       @disks.stub :get, @get_managed_disk_response do
         @virtual_machines.stub :create_or_update, @get_vm_managed_disk_response do
-          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG' }
-          assert_equal @service.attach_data_disk_to_vm(input_params, false, 'ReadOnly'), @get_vm_managed_disk_response
+          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG', caching: 'ReadOnly' }
+          assert_equal @service.attach_data_disk_to_vm(input_params, false), @get_vm_managed_disk_response
         end
       end
     end
     @virtual_machines.stub :get, @get_vm_response do
       @disks.stub :get, @get_managed_disk_response do
         @virtual_machines.stub :create_or_update, @get_vm_managed_disk_response do
-          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG' }
-          assert_equal @service.attach_data_disk_to_vm(input_params, false, 'ReadWrite'), @get_vm_managed_disk_response
+          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG', caching: 'ReadWrite' }
+          assert_equal @service.attach_data_disk_to_vm(input_params, false), @get_vm_managed_disk_response
         end
       end
     end

--- a/test/requests/compute/test_attach_data_disk_to_vm.rb
+++ b/test/requests/compute/test_attach_data_disk_to_vm.rb
@@ -42,6 +42,22 @@ class TestAttachDataDiskToVM < Minitest::Test
         end
       end
     end
+    @virtual_machines.stub :get, @get_vm_response do
+      @disks.stub :get, @get_managed_disk_response do
+        @virtual_machines.stub :create_or_update, @get_vm_managed_disk_response do
+          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG' }
+          assert_equal @service.attach_data_disk_to_vm(input_params, false, 'ReadOnly'), @get_vm_managed_disk_response
+        end
+      end
+    end
+    @virtual_machines.stub :get, @get_vm_response do
+      @disks.stub :get, @get_managed_disk_response do
+        @virtual_machines.stub :create_or_update, @get_vm_managed_disk_response do
+          input_params = { vm_name: 'ManagedVM', vm_resource_group: 'ManagedRG', disk_name: 'ManagedDataDisk1', disk_size_gb: 100, disk_resource_group: 'ManagedRG' }
+          assert_equal @service.attach_data_disk_to_vm(input_params, false, 'ReadWrite'), @get_vm_managed_disk_response
+        end
+      end
+    end
   end
 
   def test_attach_data_disk_to_vm_failure


### PR DESCRIPTION
For `managed disks`, the option to select different types of `caching` has been added. The following options are available
- ReadWrite
- ReadOnly
- None

`None` is set by default.

The respective documentation, unit tests and integration tests have been updated as well.