### PR TITLE
Updated azure-storage dependency

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_traffic_manager', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_sql', '~> 0.9.0'
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
-  spec.add_dependency 'azure-storage', '= 0.11.5.preview'
+  spec.add_dependency 'azure-storage', '= 0.12.2.preview'
   spec.add_dependency 'vhd', '0.0.4'
   spec.add_dependency 'mime-types', '~> 1.25'
 end


### PR DESCRIPTION
Previous version of `azure-storage` dependency (0.11.5.preview) used `nokogiri` gem (version ~> 1.6.0) that has multiple serious security vulnerabilities:
* [https://nvd.nist.gov/vuln/detail/CVE-2018-14404](https://nvd.nist.gov/vuln/detail/CVE-2018-14404) [moderate severity]
* [https://nvd.nist.gov/vuln/detail/CVE-2016-4658](https://nvd.nist.gov/vuln/detail/CVE-2016-4658) [high severity]
* [https://nvd.nist.gov/vuln/detail/CVE-2017-5029](https://nvd.nist.gov/vuln/detail/CVE-2017-5029) [low severity]
* [https://nvd.nist.gov/vuln/detail/CVE-2017-18258](https://nvd.nist.gov/vuln/detail/CVE-2017-18258) [moderate severity]
* [https://nvd.nist.gov/vuln/detail/CVE-2017-9050](https://nvd.nist.gov/vuln/detail/CVE-2017-9050) [critical severity]

This PR updates `azure-storage` dependency to version `0.12.2.preview` that dropped `nokogiri` dependency at all, therefore eliminating a problem.
