### PR TITLE
Printing Header Information for Fog Custom AzureOperationError

### DIFF
--- a/lib/fog/azurerm/custom_fog_errors.rb
+++ b/lib/fog/azurerm/custom_fog_errors.rb
@@ -6,6 +6,40 @@ module Fog
       def initialize(message, azure_exception)
         super(azure_exception.request, azure_exception.response, azure_exception.body, "Exception in #{message}")
       end
+
+      def print_subscription_limits_information
+        request_method = @request.method
+        subscription_id = @request.path_params['subscriptionId']
+
+        limit_value = remaining_subscription_request_limits(@response)
+
+        puts "Subscription: '#{subscription_id}'. Request Method: '#{request_method}'. \nLimit Value: #{limit_value['header']}: #{limit_value['value']}\n" unless limit_value.empty?
+      end
+
+      def remaining_subscription_request_limits(response)
+        limit = {}
+        # handles both read and write limits
+        if response.headers.key? 'x-ms-ratelimit-remaining-subscription-resource-requests'
+          limit['header'] = 'x-ms-ratelimit-remaining-subscription-resource-requests'
+          limit['value'] = response.headers['x-ms-ratelimit-remaining-subscription-resource-requests']
+
+        # limit for collection API calls
+        elsif response.headers.key? 'x-ms-ratelimit-remaining-subscription-resource-entities-read'
+          limit['header'] = 'x-ms-ratelimit-remaining-subscription-resource-entities-read'
+          limit['value'] = response.headers['x-ms-ratelimit-remaining-subscription-resource-entities-read']
+
+        # read requests limit
+        elsif response.headers.key? 'x-ms-ratelimit-remaining-subscription-reads'
+          limit['header'] = 'x-ms-ratelimit-remaining-subscription-reads'
+          limit['value'] = response.headers['x-ms-ratelimit-remaining-subscription-reads']
+
+        # write requests limit
+        elsif response.headers.key? 'x-ms-ratelimit-remaining-subscription-writes'
+          limit['header'] = 'x-ms-ratelimit-remaining-subscription-writes'
+          limit['value'] = response.headers['x-ms-ratelimit-remaining-subscription-writes']
+        end
+        limit
+      end
     end
 
     # This is a custom Fog exception inherited from Azure::Core::Http::HTTPError

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -53,7 +53,7 @@ def raise_azure_exception(exception, msg)
   raise exception unless exception.is_a?(MsRestAzure::AzureOperationError)
 
   azure_operation_error = Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
-  azure_operation_error.print_subscription_limits_information unless azure_operation_error.response.nil?
+  azure_operation_error.print_subscription_limits_information if !azure_operation_error.request.nil? && !azure_operation_error.response.nil?
   raise azure_operation_error
 end
 

--- a/lib/fog/azurerm/utilities/general.rb
+++ b/lib/fog/azurerm/utilities/general.rb
@@ -50,8 +50,11 @@ end
 
 def raise_azure_exception(exception, msg)
   raise Fog::AzureRM::CustomAzureCoreHttpError.new(exception) if exception.is_a?(Azure::Core::Http::HTTPError)
-  raise Fog::AzureRM::CustomAzureOperationError.new(msg, exception) if exception.is_a?(MsRestAzure::AzureOperationError)
-  raise exception
+  raise exception unless exception.is_a?(MsRestAzure::AzureOperationError)
+
+  azure_operation_error = Fog::AzureRM::CustomAzureOperationError.new(msg, exception)
+  azure_operation_error.print_subscription_limits_information unless azure_operation_error.response.nil?
+  raise azure_operation_error
 end
 
 # Make sure if input_params(Hash) contains all keys present in required_params(Array)


### PR DESCRIPTION
Whenever an exception is thrown from `fog-azure-rm`, we print information like `x-ms-ratelimit-remaining-subscription-reads` and `x-ms-ratelimit-remaining-subscription-writes` from the headers to the standard output.