### PR TITLE
Added Null Check for Path Params Attribute in Azure Exception

### DIFF
--- a/lib/fog/azurerm/custom_fog_errors.rb
+++ b/lib/fog/azurerm/custom_fog_errors.rb
@@ -9,7 +9,7 @@ module Fog
 
       def print_subscription_limits_information
         request_method = @request.method
-        subscription_id = @request.path_params['subscriptionId']
+        subscription_id = @request.path_params['subscriptionId'] unless @request.path_params.nil?
 
         limit_value = remaining_subscription_request_limits(@response)
 


### PR DESCRIPTION
Summary: When printing READ and WRITE limits for Azure API requests, an exception occurs when trying to access `Subscription ID` key inside the `path_params` hash that can be null at times. 
A check has been added to first ensure that the hash is not null before extracting the Subscription ID from it.

Differential Revision: https://phabricator.confiz.com/D13145