### PR TITLE
Fix error when using a mocked check_vm_exists request

### DIFF
--- a/lib/fog/azurerm/requests/compute/check_vm_exists.rb
+++ b/lib/fog/azurerm/requests/compute/check_vm_exists.rb
@@ -30,7 +30,7 @@ module Fog
       end
       # This class provides the mock implementation for unit tests.
       class Mock
-        def check_vm_exists(_resource_group, _name)
+        def check_vm_exists(_resource_group, _name, _async)
           true
         end
       end


### PR DESCRIPTION
This is a simple update to fix the following error when testing with Fog.mock! enabled.

`ArgumentError: wrong number of arguments (given 3, expected 2)`

Signed-off-by: gscho <greg.c.schofield@gmail.com>