### PR TITLE
add fog debug var

### DIFF
--- a/lib/fog/azurerm.rb
+++ b/lib/fog/azurerm.rb
@@ -78,7 +78,7 @@ module Fog
     # We cannot necessarily set the DEBUG environment variable for fog-azure-rm because
     # that would log the complete HTTP body since this variable is also used by the Azure storage SDK.
     # Instead let's offer another way to enable fog-azure-rm debug logging
-    Fog::Logger.instance_variable_get(:@channels)[:debug] = ::STDERR if ENV['FOG_DEBUG']
+    Fog::Logger[:debug] = ::STDERR if ENV["FOG_DEBUG"]
     extend Fog::Provider
     service(:resources, 'Resources')
     service(:dns, 'DNS')

--- a/lib/fog/azurerm.rb
+++ b/lib/fog/azurerm.rb
@@ -75,6 +75,10 @@ module Fog
 
   # Main AzureRM fog Provider Module
   module AzureRM
+    # We cannot necessarily set the DEBUG environment variable for fog-azure-rm because
+    # that would log the complete HTTP body since this variable is also used by the Azure storage SDK.
+    # Instead let's offer another way to enable fog-azure-rm debug logging
+    Fog::Logger.instance_variable_get(:@channels)[:debug] = ::STDERR if ENV['FOG_DEBUG']
     extend Fog::Provider
     service(:resources, 'Resources')
     service(:dns, 'DNS')


### PR DESCRIPTION
We need to enable DEBUG logging for fog-azure-rm but we cannot necessarily set the DEBUG environment variable for fog-azure-rm because that would log the complete HTTP body because of https://github.com/fog/fog-azure-rm/blob/9da5cc04189cd1ec751c5bc1e2f5406ce6b179d0/lib/fog/azurerm/storage.rb#L96-L97.
Proposal is to instead offer another env variable 'FOG_DEBUG' to enable only logging on fog-azure-rm level.