### PR TITLE
Add blob operation timeout

### DIFF
--- a/lib/fog/azurerm/requests/storage/commit_blob_blocks.rb
+++ b/lib/fog/azurerm/requests/storage/commit_blob_blocks.rb
@@ -4,13 +4,13 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def commit_blob_blocks(container_name, blob_name, blocks, options = {})
-          myOptions = options.clone
-          myOptions[:request_id] = SecureRandom.uuid
-          msg = "commit_blob_blocks: Complete uploading #{blob_name} to the container #{container_name}. options: #{myOptions}"
+          my_options = options.clone
+          my_options[:request_id] = SecureRandom.uuid
+          msg = "commit_blob_blocks: Complete uploading #{blob_name} to the container #{container_name}. options: #{my_options}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.commit_blob_blocks(container_name, blob_name, blocks, myOptions)
+            @blob_client.commit_blob_blocks(container_name, blob_name, blocks, my_options)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end

--- a/lib/fog/azurerm/requests/storage/commit_blob_blocks.rb
+++ b/lib/fog/azurerm/requests/storage/commit_blob_blocks.rb
@@ -4,12 +4,13 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def commit_blob_blocks(container_name, blob_name, blocks, options = {})
-          options[:request_id] = SecureRandom.uuid
-          msg = "commit_blob_blocks: Complete uploading #{blob_name} to the container #{container_name}. options: #{options}"
+          myOptions = options.clone
+          myOptions[:request_id] = SecureRandom.uuid
+          msg = "commit_blob_blocks: Complete uploading #{blob_name} to the container #{container_name}. options: #{myOptions}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.commit_blob_blocks(container_name, blob_name, blocks, options)
+            @blob_client.commit_blob_blocks(container_name, blob_name, blocks, myOptions)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end

--- a/lib/fog/azurerm/requests/storage/create_block_blob.rb
+++ b/lib/fog/azurerm/requests/storage/create_block_blob.rb
@@ -4,19 +4,19 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def create_block_blob(container_name, blob_name, body, options = {})
-          myOptions = options.clone
-          myOptions[:request_id] = SecureRandom.uuid
-          if myOptions[:create_block_blob_timeout] then
-            Fog::Logger.debug "create_block_blob: Setting blob operation timeout to #{myOptions[:create_block_blob_timeout]} seconds"
-            myOptions[:timeout] = myOptions[:create_block_blob_timeout] 
+          my_options = options.clone
+          my_options[:request_id] = SecureRandom.uuid
+          if my_options[:create_block_blob_timeout]
+            Fog::Logger.debug "create_block_blob: Setting blob operation timeout to #{my_options[:create_block_blob_timeout]} seconds"
+            my_options[:timeout] = my_options[:create_block_blob_timeout]
           else
             # Server side default is 10 minutes per megabyte on average, lets use an avg. speed of at least 100KiB/s
             # => 64MiB (max for create block) should be uploaded in 67108864B / 102400B/s = 655.36s
-            Fog::Logger.debug "create_block_blob: Setting blob operation timeout to default of 656 seconds"
-            myOptions[:timeout] = 656
+            Fog::Logger.debug 'create_block_blob: Setting blob operation timeout to default of 656 seconds'
+            my_options[:timeout] = 656
           end
 
-          msg = "create_block_blob #{blob_name} to the container #{container_name}. options: #{myOptions}"
+          msg = "create_block_blob #{blob_name} to the container #{container_name}. options: #{my_options}"
           Fog::Logger.debug msg
 
           begin
@@ -33,13 +33,13 @@ module Fog
               data = body.read
             else
               data = Fog::Storage.parse_data(body)
-              myOptions[:content_length] = data[:headers]['Content-Length']
-              myOptions[:content_type] = data[:headers]['Content-Type']
+              my_options[:content_length] = data[:headers]['Content-Length']
+              my_options[:content_type] = data[:headers]['Content-Type']
               data = data[:body]
             end
 
             raise ArgumentError.new('The maximum size for a block blob created via create_block_blob is 64 MB.') if !data.nil? && Fog::Storage.get_body_size(data) > 64 * 1024 * 1024
-            blob = @blob_client.create_block_blob(container_name, blob_name, data, myOptions)
+            blob = @blob_client.create_block_blob(container_name, blob_name, data, my_options)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end

--- a/lib/fog/azurerm/requests/storage/create_block_blob.rb
+++ b/lib/fog/azurerm/requests/storage/create_block_blob.rb
@@ -4,8 +4,19 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def create_block_blob(container_name, blob_name, body, options = {})
-          options[:request_id] = SecureRandom.uuid
-          msg = "create_block_blob #{blob_name} to the container #{container_name}. options: #{options}"
+          myOptions = options.clone
+          myOptions[:request_id] = SecureRandom.uuid
+          if myOptions[:create_block_blob_timeout] then
+            Fog::Logger.debug "create_block_blob: Setting blob operation timeout to #{myOptions[:create_block_blob_timeout]} seconds"
+            myOptions[:timeout] = myOptions[:create_block_blob_timeout] 
+          else
+            # Server side default is 10 minutes per megabyte on average, lets use an avg. speed of at least 100KiB/s
+            # => 64MiB (max for create block) should be uploaded in 67108864B / 102400B/s = 655.36s
+            Fog::Logger.debug "create_block_blob: Setting blob operation timeout to default of 656 seconds"
+            myOptions[:timeout] = 656
+          end
+
+          msg = "create_block_blob #{blob_name} to the container #{container_name}. options: #{myOptions}"
           Fog::Logger.debug msg
 
           begin
@@ -22,13 +33,13 @@ module Fog
               data = body.read
             else
               data = Fog::Storage.parse_data(body)
-              options[:content_length] = data[:headers]['Content-Length']
-              options[:content_type] = data[:headers]['Content-Type']
+              myOptions[:content_length] = data[:headers]['Content-Length']
+              myOptions[:content_type] = data[:headers]['Content-Type']
               data = data[:body]
             end
 
             raise ArgumentError.new('The maximum size for a block blob created via create_block_blob is 64 MB.') if !data.nil? && Fog::Storage.get_body_size(data) > 64 * 1024 * 1024
-            blob = @blob_client.create_block_blob(container_name, blob_name, data, options)
+            blob = @blob_client.create_block_blob(container_name, blob_name, data, myOptions)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end

--- a/lib/fog/azurerm/requests/storage/delete_blob.rb
+++ b/lib/fog/azurerm/requests/storage/delete_blob.rb
@@ -4,13 +4,13 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def delete_blob(container_name, blob_name, options = {})
-          myOptions = options.clone
-          myOptions[:request_id] = SecureRandom.uuid
-          msg = "Deleting blob: #{blob_name} in container #{container_name}. options: #{myOptions}"
+          my_options = options.clone
+          my_options[:request_id] = SecureRandom.uuid
+          msg = "Deleting blob: #{blob_name} in container #{container_name}. options: #{my_options}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.delete_blob(container_name, blob_name, myOptions)
+            @blob_client.delete_blob(container_name, blob_name, my_options)
           rescue Azure::Core::Http::HTTPError => ex
             return true if ex.message.include?('(404)')
             raise_azure_exception(ex, msg)

--- a/lib/fog/azurerm/requests/storage/delete_blob.rb
+++ b/lib/fog/azurerm/requests/storage/delete_blob.rb
@@ -4,12 +4,13 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def delete_blob(container_name, blob_name, options = {})
-          options[:request_id] = SecureRandom.uuid
-          msg = "Deleting blob: #{blob_name} in container #{container_name}. options: #{options}"
+          myOptions = options.clone
+          myOptions[:request_id] = SecureRandom.uuid
+          msg = "Deleting blob: #{blob_name} in container #{container_name}. options: #{myOptions}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.delete_blob(container_name, blob_name, options)
+            @blob_client.delete_blob(container_name, blob_name, myOptions)
           rescue Azure::Core::Http::HTTPError => ex
             return true if ex.message.include?('(404)')
             raise_azure_exception(ex, msg)

--- a/lib/fog/azurerm/requests/storage/put_blob_block.rb
+++ b/lib/fog/azurerm/requests/storage/put_blob_block.rb
@@ -4,12 +4,23 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def put_blob_block(container_name, blob_name, block_id, data, options = {})
-          options[:request_id] = SecureRandom.uuid
-          msg = "put_blob_block block_id: #{block_id} / #{blob_name} to the container #{container_name}. options: #{options}"
+          myOptions = options.clone
+          myOptions[:request_id] = SecureRandom.uuid
+          if myOptions[:put_blob_block_timeout] then
+            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to #{myOptions[:put_blob_block_timeout]} seconds"
+            myOptions[:timeout] = myOptions[:put_blob_block_timeout] 
+          else
+            # Server side default is 10 minutes per megabyte on average, lets use an avg. speed of at least 100KiB/s
+            defaultTimeout = MAXIMUM_CHUNK_SIZE / 102400
+            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to default of #{defaultTimeout} seconds"
+            myOptions[:timeout] = defaultTimeout
+          end
+
+          msg = "put_blob_block block_id: #{block_id} / #{blob_name} to the container #{container_name}. options: #{myOptions}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.put_blob_block(container_name, blob_name, block_id, data, options)
+            @blob_client.put_blob_block(container_name, blob_name, block_id, data, myOptions)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end

--- a/lib/fog/azurerm/requests/storage/put_blob_block.rb
+++ b/lib/fog/azurerm/requests/storage/put_blob_block.rb
@@ -4,23 +4,23 @@ module Fog
       # This class provides the actual implementation for service calls.
       class Real
         def put_blob_block(container_name, blob_name, block_id, data, options = {})
-          myOptions = options.clone
-          myOptions[:request_id] = SecureRandom.uuid
-          if myOptions[:put_blob_block_timeout] then
-            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to #{myOptions[:put_blob_block_timeout]} seconds"
-            myOptions[:timeout] = myOptions[:put_blob_block_timeout] 
+          my_options = options.clone
+          my_options[:request_id] = SecureRandom.uuid
+          if my_options[:put_blob_block_timeout]
+            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to #{my_options[:put_blob_block_timeout]} seconds"
+            my_options[:timeout] = my_options[:put_blob_block_timeout]
           else
             # Server side default is 10 minutes per megabyte on average, lets use an avg. speed of at least 100KiB/s
-            defaultTimeout = MAXIMUM_CHUNK_SIZE / 102400
-            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to default of #{defaultTimeout} seconds"
-            myOptions[:timeout] = defaultTimeout
+            default_timeout = MAXIMUM_CHUNK_SIZE / 102400
+            Fog::Logger.debug "put_blob_block: Setting blob operation timeout to default of #{default_timeout} seconds"
+            my_options[:timeout] = default_timeout
           end
 
-          msg = "put_blob_block block_id: #{block_id} / #{blob_name} to the container #{container_name}. options: #{myOptions}"
+          msg = "put_blob_block block_id: #{block_id} / #{blob_name} to the container #{container_name}. options: #{my_options}"
           Fog::Logger.debug msg
 
           begin
-            @blob_client.put_blob_block(container_name, blob_name, block_id, data, myOptions)
+            @blob_client.put_blob_block(container_name, blob_name, block_id, data, my_options)
           rescue Azure::Core::Http::HTTPError => ex
             raise_azure_exception(ex, msg)
           end


### PR DESCRIPTION
Following up on PR #431 to implement recommendation from the Azure Storage Team.

This PR implements a blob operation timeout for the API calls that are used by multipart_save_block_blob
In addition, is also generates a clone of the options array to make it thread safe. In my test I saw that the 8 upload threads were changing the options array for other threads. This could also be the root cause for a blocking situation, when one thread overrides the Content-Length property of another thread.