### PR TITLE
Fix bug name error for enumeration result of azure storage

### DIFF
--- a/lib/fog/azurerm/requests/storage/list_blobs.rb
+++ b/lib/fog/azurerm/requests/storage/list_blobs.rb
@@ -21,7 +21,7 @@ module Fog
               Fog::Logger.debug msg
               temp = @blob_client.list_blobs(container_name, options)
               # Workaround for the issue https://github.com/Azure/azure-storage-ruby/issues/37
-              raise temp unless temp.instance_of?(Azure::Service::EnumerationResults)
+              raise temp unless temp.instance_of?(Azure::Storage::Common::Service::EnumerationResults)
 
               blobs += temp unless temp.empty?
               break if temp.continuation_token.nil? || temp.continuation_token.empty?

--- a/lib/fog/azurerm/requests/storage/list_containers.rb
+++ b/lib/fog/azurerm/requests/storage/list_containers.rb
@@ -16,7 +16,7 @@ module Fog
               Fog::Logger.debug msg
               temp = @blob_client.list_containers(options)
               # Workaround for the issue https://github.com/Azure/azure-storage-ruby/issues/37
-              raise temp unless temp.instance_of?(Azure::Service::EnumerationResults)
+              raise temp unless temp.instance_of?(Azure::Storage::Common::Service::EnumerationResults)
 
               containers += temp unless temp.empty?
               break if temp.continuation_token.nil? || temp.continuation_token.empty?

--- a/test/requests/storage/test_list_blobs.rb
+++ b/test/requests/storage/test_list_blobs.rb
@@ -13,11 +13,11 @@ class TestListBlobs < Minitest::Test
     @blob_client = @service.instance_variable_get(:@blob_client)
 
     @blob_list = ApiStub::Requests::Storage::File.blob_list
-    @blobs1 = Azure::Service::EnumerationResults.new
+    @blobs1 = Azure::Storage::Common::Service::EnumerationResults.new
     @blobs1.continuation_token = 'marker'
     @blobs1.push(@blob_list[0])
     @blobs1.push(@blob_list[1])
-    @blobs2 = Azure::Service::EnumerationResults.new
+    @blobs2 = Azure::Storage::Common::Service::EnumerationResults.new
     @blobs2.push(@blob_list[2])
     @blobs2.push(@blob_list[3])
   end

--- a/test/requests/storage/test_list_containers.rb
+++ b/test/requests/storage/test_list_containers.rb
@@ -13,11 +13,11 @@ class TestListContainers < Minitest::Test
     @blob_client = @service.instance_variable_get(:@blob_client)
 
     @containers = ApiStub::Requests::Storage::Directory.container_list
-    @containers1 = Azure::Service::EnumerationResults.new
+    @containers1 = Azure::Storage::Common::Service::EnumerationResults.new
     @containers1.continuation_token = 'marker'
     @containers1.push(@containers[0])
     @containers1.push(@containers[1])
-    @containers2 = Azure::Service::EnumerationResults.new
+    @containers2 = Azure::Storage::Common::Service::EnumerationResults.new
     @containers2.push(@containers[2])
   end
 


### PR DESCRIPTION
`Loading development environment (Rails 6.0.3.4)
[1] pry(main)> Azure::Storage::Common::Service::EnumerationResults.new
=> []
[2] pry(main)> Azure::Service::EnumerationResults.new
NameError: uninitialized constant Azure::Service
Did you mean?  Device
from (pry):2:in `__pry__`