### PR TITLE
Added check to update error message on invalid azure credentials

### DIFF
--- a/lib/fog/azurerm/custom_fog_errors.rb
+++ b/lib/fog/azurerm/custom_fog_errors.rb
@@ -4,7 +4,12 @@ module Fog
     # This is a custom Fog exception inherited from MsRestAzure::AzureOperationError
     class CustomAzureOperationError < MsRestAzure::AzureOperationError
       def initialize(message, azure_exception)
-        super(azure_exception.request, azure_exception.response, azure_exception.body, "Exception in #{message}")
+        message = "Exception in #{message}"
+        if azure_exception.request.nil? && azure_exception.response.nil? &&
+           azure_exception.body.nil? && !azure_exception.message.nil?
+          message = message +  " #{Fog::JSON.decode(azure_exception.message)['message']}"
+        end
+        super(azure_exception.request, azure_exception.response, azure_exception.body, message)
       end
 
       def print_subscription_limits_information


### PR DESCRIPTION
In case of wrong Azure credentials, the error message present in the exception response does not clearly indicate that the Azure credentials are wrong.
Updated the “initialize” method of the `custom_fog_errors` file to display a proper error message indicating that the azure credentials are wrong.