### PR TITLE
Upgrade mime-types to 3.0

### DIFF
--- a/fog-azure-rm.gemspec
+++ b/fog-azure-rm.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'azure_mgmt_key_vault', '~> 0.9.0'
   spec.add_dependency 'azure-storage', '= 0.11.5.preview'
   spec.add_dependency 'vhd', '0.0.4'
-  spec.add_dependency 'mime-types', '~> 1.25'
+  spec.add_dependency 'mime-types', '~> 3.0'
 end


### PR DESCRIPTION
This PR upgrades mime-types, no longer restricting it to be an old version `1.25`

`mime-types` 1.x has been [out of support since 2015](https://www.rubydoc.info/gems/mime-types/3.1)

2.x has been out of support since 2017.

This dependencies causes several issues, from #390, #359, to being unable to support #367 in master.

Previously, in #367, the reason given for not updating the mime-types dependency was that another (seemingly unrelated, except that in that it consumes this gem) app, [OneOps](https://github.com/oneops/oneops), relied on mime-types 1.x.  That app itself is not supported anymore.


We would love to have this merged in so we can eventually stop maintaining our own separate branch `fog-arm-cf` and contribute to the main release.

Thanks,

Seth


